### PR TITLE
`/recordNodeMap` endpoints for easier recording generation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,12 +12,24 @@ pnpm install
 
 ### Run the inspector locally:
 
+To just run the UI:
+
 ```shell
 cd inspector
 pnpm start
 ```
 
 This runs Vite and serves the Crank-based inspector UI. Open http://localhost:5173 (or whatever Vite prints).
+
+To run server with the example file, use"
+
+```shell
+node --import tsx --import ./loader.ts examples/example.ts --suspend
+```
+
+This will run the loader with an example effection program. It serves both a live stream of data, and also the built files for the UI. If you are working on the UI on the `/live` integration, you may need to use both of these dev servers, and `localhost:5173` appropriately proxies to port `:41000`. If you have run a `pnpm run build`, then you can directly visit http://localhost:41000.
+
+### Checks
 
 - Run tests & checks (from repo root):
   - Run tests: `pnpm test`

--- a/README.md
+++ b/README.md
@@ -24,14 +24,11 @@ When started this way the inspector will launch a small SSE server (default port
 
 ### Recording ✅
 
-The UI supports loading saved recordings useful for review and sharing. From the Home screen click **Load Recording → Browse files** and choose a `.json` or `.effection` file. A recording is a JSON array of NodeMap snapshots. The inspector accepts `.json` and `.effection` files.
+The UI supports loading saved recordings useful for review and sharing. From the Home screen click `Load Recording` > `Browse files` and choose a `.json` or `.effection` file. A recording is a JSON array of NodeMap snapshots. The inspector accepts `.json` and `.effection` files.
 
 #### Creating a recording from a live session:
 
 You can capture the SSE stream from a running inspector and save the emitted data. Start by using [the instructions for running the process live](#live).
-
-> [!WARNING]
-> This generates a stream of patch-like updates rather than an array of heirarchies, the latter of which is required to render. We need to add one more step to make the conversion somehow or otherwise adjust for a different process.
 
 ```bash
 # Start capturing and it will close once your effection process closes

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can capture the SSE stream from a running inspector and save the emitted dat
 
 ```bash
 # Start capturing and it will close once your effection process closes
-curl -sN -X POST http://localhost:41000/watchScopes \
+curl -sN -X POST http://localhost:41000/recordNodeMap \
   -H "Accept: text/event-stream" -d '[]' \
   | jq -R -s 'split("\n") | map(select(startswith("data: "))) | map(.[6:] | fromjson)' \
   > recording.json

--- a/crank/app/components/render-recording.tsx
+++ b/crank/app/components/render-recording.tsx
@@ -9,7 +9,7 @@ import { arrayLoader, useRecording } from "../data/recording.ts";
 import type { Recording } from "../data/recording.ts";
 import { raf, sample } from "../data/sample.ts";
 import { stratify } from "../data/stratify.ts";
-import type { NodeMap } from "../data/types.ts";
+import type { NodeMap } from "../../../lib/update-node-map.ts";
 import { PlaybackControls } from "../components/playback-controls.tsx";
 import type { Stratification } from "../data/stratify.ts";
 import { StructureInspector } from "./structure-inspector.tsx";

--- a/crank/app/data/recording.ts
+++ b/crank/app/data/recording.ts
@@ -1,5 +1,5 @@
 import { type Stream, type Operation, createSignal } from "effection";
-import type { NodeMap } from "./types.ts";
+import type { NodeMap } from "../../../lib/update-node-map.ts";
 import { createSubject } from "@effectionx/stream-helpers";
 import { pipe } from "remeda";
 

--- a/crank/app/data/sample.ts
+++ b/crank/app/data/sample.ts
@@ -7,7 +7,7 @@ import {
   type Operation,
   type Yielded,
 } from "effection";
-import type { Transform } from "./types.ts";
+import type { Transform } from "../../../lib/update-node-map.ts";
 
 /**
  * Sample a stream at an interval specified by `interval`

--- a/crank/app/data/sample.ts
+++ b/crank/app/data/sample.ts
@@ -1,12 +1,4 @@
-import {
-  action,
-  all,
-  scoped,
-  spawn,
-  withResolvers,
-  type Operation,
-  type Yielded,
-} from "effection";
+import { action, all, scoped, spawn, withResolvers, type Operation, type Yielded } from "effection";
 import type { Transform } from "../../../lib/update-node-map.ts";
 
 /**

--- a/crank/app/data/stratify.ts
+++ b/crank/app/data/stratify.ts
@@ -1,5 +1,6 @@
 import { map } from "@effectionx/stream-helpers";
-import type { Hierarchy, NodeMap, Transform } from "./types.ts";
+import type { Hierarchy } from "./types.ts";
+import type { Transform, NodeMap } from "../../../lib/update-node-map.ts";
 
 export type HierarchyMap = Record<string, Hierarchy>;
 

--- a/crank/app/data/types.ts
+++ b/crank/app/data/types.ts
@@ -1,23 +1,6 @@
-import type { Stream } from "effection";
-
-export interface Node {
-  id: string;
-  parentId?: string;
-  data: Record<string, unknown>;
-}
-
-export type NodeMap = Record<string, Node>;
-
 export interface Hierarchy {
   id: string;
   parentId?: string;
   data: Record<string, unknown>;
   children: Hierarchy[];
 }
-
-/**
- * A function that transforms one stream into another
- */
-export type Transform<A, B> = <TClose>(
-  input: Stream<A, TClose>,
-) => Stream<B, TClose>;

--- a/crank/app/demo.json
+++ b/crank/app/demo.json
@@ -31,8 +31,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -46,23 +46,50 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
+        }
+      }
+    },
+    "7": {
+      "id": "7",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
         }
       }
     }
@@ -99,8 +126,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -114,368 +141,55 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "39": {
-      "id": "39",
-      "parentId": "32",
-      "data": {}
-    }
-  },
-  {
-    "0": {
-      "id": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Global"
-        }
-      }
-    },
-    "1": {
-      "id": "1",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Inspector"
-        }
-      }
-    },
-    "2": {
-      "id": "2",
-      "parentId": "0",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
           "name": "anonymous"
         }
       }
     },
-    "3": {
-      "id": "3",
-      "parentId": "2",
-      "data": {
-        "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
-        }
-      }
-    },
-    "4": {
-      "id": "4",
-      "parentId": "1",
-      "data": {
-        "@effection/attributes": {
-          "name": "SSEServer",
-          "port": 41000
-        }
-      }
-    },
-    "31": {
-      "id": "31",
-      "parentId": "4",
-      "data": {
-        "@effection/attributes": {
-          "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
-        }
-      }
-    },
-    "32": {
-      "id": "32",
-      "parentId": "31",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "39": {
-      "id": "39",
-      "parentId": "32",
-      "data": {}
-    },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
-    }
-  },
-  {
-    "0": {
-      "id": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Global"
-        }
-      }
-    },
-    "1": {
-      "id": "1",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Inspector"
-        }
-      }
-    },
-    "2": {
-      "id": "2",
-      "parentId": "0",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
           "name": "anonymous"
         }
       }
     },
-    "3": {
-      "id": "3",
-      "parentId": "2",
-      "data": {
-        "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
-        }
-      }
-    },
-    "4": {
-      "id": "4",
-      "parentId": "1",
-      "data": {
-        "@effection/attributes": {
-          "name": "SSEServer",
-          "port": 41000
-        }
-      }
-    },
-    "31": {
-      "id": "31",
-      "parentId": "4",
-      "data": {
-        "@effection/attributes": {
-          "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
-        }
-      }
-    },
-    "32": {
-      "id": "32",
-      "parentId": "31",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "39": {
-      "id": "39",
-      "parentId": "32",
-      "data": {}
-    },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
-    },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
-    }
-  },
-  {
-    "0": {
-      "id": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Global"
-        }
-      }
-    },
-    "1": {
-      "id": "1",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Inspector"
-        }
-      }
-    },
-    "2": {
-      "id": "2",
-      "parentId": "0",
+    "8": {
+      "id": "8",
+      "parentId": "7",
       "data": {
         "@effection/attributes": {
           "name": "anonymous"
         }
       }
     },
-    "3": {
-      "id": "3",
-      "parentId": "2",
+    "9": {
+      "id": "9",
+      "parentId": "6",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "EventStream"
         }
       }
     },
-    "4": {
-      "id": "4",
-      "parentId": "1",
-      "data": {
-        "@effection/attributes": {
-          "name": "SSEServer",
-          "port": 41000
-        }
-      }
-    },
-    "31": {
-      "id": "31",
-      "parentId": "4",
-      "data": {
-        "@effection/attributes": {
-          "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
-        }
-      }
-    },
-    "32": {
-      "id": "32",
-      "parentId": "31",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "39": {
-      "id": "39",
-      "parentId": "32",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
-    },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
-    }
-  },
-  {
-    "0": {
-      "id": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Global"
-        }
-      }
-    },
-    "1": {
-      "id": "1",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Inspector"
-        }
-      }
-    },
-    "2": {
-      "id": "2",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "anonymous"
-        }
-      }
-    },
-    "3": {
-      "id": "3",
-      "parentId": "2",
-      "data": {
-        "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
-        }
-      }
-    },
-    "4": {
-      "id": "4",
-      "parentId": "1",
-      "data": {
-        "@effection/attributes": {
-          "name": "SSEServer",
-          "port": 41000
-        }
-      }
-    },
-    "31": {
-      "id": "31",
-      "parentId": "4",
-      "data": {
-        "@effection/attributes": {
-          "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
-        }
-      }
-    },
-    "32": {
-      "id": "32",
-      "parentId": "31",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "39": {
-      "id": "39",
-      "parentId": "32",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
-    },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
-    },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {}
     }
@@ -512,8 +226,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -527,53 +241,61 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     }
@@ -610,8 +332,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -625,59 +347,67 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
+    "12": {
+      "id": "12",
+      "parentId": "11",
       "data": {}
     }
   },
@@ -713,8 +443,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -728,62 +458,448 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
+    "12": {
+      "id": "12",
+      "parentId": "11",
+      "data": {}
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
+      "data": {}
+    }
+  },
+  {
+    "0": {
+      "id": "0",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "Global"
+        }
+      }
+    },
+    "1": {
+      "id": "1",
+      "parentId": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "Inspector"
+        }
+      }
+    },
+    "2": {
+      "id": "2",
+      "parentId": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "3": {
+      "id": "3",
+      "parentId": "2",
+      "data": {
+        "@effection/attributes": {
+          "name": "Main",
+          "args": "--suspend"
+        }
+      }
+    },
+    "4": {
+      "id": "4",
+      "parentId": "1",
+      "data": {
+        "@effection/attributes": {
+          "name": "SSEServer",
+          "port": 41000
+        }
+      }
+    },
+    "5": {
+      "id": "5",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/recordNodeMap"
+        }
+      }
+    },
+    "6": {
+      "id": "6",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "7": {
+      "id": "7",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "11": {
+      "id": "11",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "12": {
+      "id": "12",
+      "parentId": "11",
+      "data": {}
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
+      "data": {}
+    },
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    }
+  },
+  {
+    "0": {
+      "id": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "Global"
+        }
+      }
+    },
+    "1": {
+      "id": "1",
+      "parentId": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "Inspector"
+        }
+      }
+    },
+    "2": {
+      "id": "2",
+      "parentId": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "3": {
+      "id": "3",
+      "parentId": "2",
+      "data": {
+        "@effection/attributes": {
+          "name": "Main",
+          "args": "--suspend"
+        }
+      }
+    },
+    "4": {
+      "id": "4",
+      "parentId": "1",
+      "data": {
+        "@effection/attributes": {
+          "name": "SSEServer",
+          "port": 41000
+        }
+      }
+    },
+    "5": {
+      "id": "5",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/recordNodeMap"
+        }
+      }
+    },
+    "6": {
+      "id": "6",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "7": {
+      "id": "7",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "11": {
+      "id": "11",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "12": {
+      "id": "12",
+      "parentId": "11",
+      "data": {}
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
+      "data": {}
+    },
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    },
+    "15": {
+      "id": "15",
+      "parentId": "12",
+      "data": {}
+    }
+  },
+  {
+    "0": {
+      "id": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "Global"
+        }
+      }
+    },
+    "1": {
+      "id": "1",
+      "parentId": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "Inspector"
+        }
+      }
+    },
+    "2": {
+      "id": "2",
+      "parentId": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "3": {
+      "id": "3",
+      "parentId": "2",
+      "data": {
+        "@effection/attributes": {
+          "name": "Main",
+          "args": "--suspend"
+        }
+      }
+    },
+    "4": {
+      "id": "4",
+      "parentId": "1",
+      "data": {
+        "@effection/attributes": {
+          "name": "SSEServer",
+          "port": 41000
+        }
+      }
+    },
+    "5": {
+      "id": "5",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/recordNodeMap"
+        }
+      }
+    },
+    "6": {
+      "id": "6",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "7": {
+      "id": "7",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "11": {
+      "id": "11",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "12": {
+      "id": "12",
+      "parentId": "11",
+      "data": {}
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
+      "data": {}
+    },
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    },
+    "15": {
+      "id": "15",
+      "parentId": "12",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
         }
       }
     }
@@ -820,8 +936,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -835,563 +951,90 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "39": {
-      "id": "39",
-      "parentId": "32",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
-    },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
-    },
-    "42": {
-      "id": "42",
-      "parentId": "4",
-      "data": {
-        "@effection/attributes": {
-          "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
-        }
-      }
-    },
-    "43": {
-      "id": "43",
-      "parentId": "42",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "44": {
-      "id": "44",
-      "parentId": "43",
-      "data": {}
-    }
-  },
-  {
-    "0": {
-      "id": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Global"
-        }
-      }
-    },
-    "1": {
-      "id": "1",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Inspector"
-        }
-      }
-    },
-    "2": {
-      "id": "2",
-      "parentId": "0",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
           "name": "anonymous"
         }
       }
     },
-    "3": {
-      "id": "3",
-      "parentId": "2",
-      "data": {
-        "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
-        }
-      }
-    },
-    "4": {
-      "id": "4",
-      "parentId": "1",
-      "data": {
-        "@effection/attributes": {
-          "name": "SSEServer",
-          "port": 41000
-        }
-      }
-    },
-    "31": {
-      "id": "31",
-      "parentId": "4",
-      "data": {
-        "@effection/attributes": {
-          "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
-        }
-      }
-    },
-    "32": {
-      "id": "32",
-      "parentId": "31",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "39": {
-      "id": "39",
-      "parentId": "32",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
-    },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
-    },
-    "42": {
-      "id": "42",
-      "parentId": "4",
-      "data": {
-        "@effection/attributes": {
-          "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
-        }
-      }
-    },
-    "43": {
-      "id": "43",
-      "parentId": "42",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "44": {
-      "id": "44",
-      "parentId": "43",
-      "data": {}
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
-      "data": {}
-    }
-  },
-  {
-    "0": {
-      "id": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Global"
-        }
-      }
-    },
-    "1": {
-      "id": "1",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Inspector"
-        }
-      }
-    },
-    "2": {
-      "id": "2",
-      "parentId": "0",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
           "name": "anonymous"
         }
       }
     },
-    "3": {
-      "id": "3",
-      "parentId": "2",
-      "data": {
-        "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
-        }
-      }
-    },
-    "4": {
-      "id": "4",
-      "parentId": "1",
-      "data": {
-        "@effection/attributes": {
-          "name": "SSEServer",
-          "port": 41000
-        }
-      }
-    },
-    "31": {
-      "id": "31",
-      "parentId": "4",
-      "data": {
-        "@effection/attributes": {
-          "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
-        }
-      }
-    },
-    "32": {
-      "id": "32",
-      "parentId": "31",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "39": {
-      "id": "39",
-      "parentId": "32",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
-    },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
-    },
-    "42": {
-      "id": "42",
-      "parentId": "4",
-      "data": {
-        "@effection/attributes": {
-          "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
-        }
-      }
-    },
-    "43": {
-      "id": "43",
-      "parentId": "42",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "44": {
-      "id": "44",
-      "parentId": "43",
-      "data": {}
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
-      "data": {}
-    },
-    "46": {
-      "id": "46",
-      "parentId": "43",
-      "data": {}
-    }
-  },
-  {
-    "0": {
-      "id": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Global"
-        }
-      }
-    },
-    "1": {
-      "id": "1",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Inspector"
-        }
-      }
-    },
-    "2": {
-      "id": "2",
-      "parentId": "0",
+    "8": {
+      "id": "8",
+      "parentId": "7",
       "data": {
         "@effection/attributes": {
           "name": "anonymous"
         }
       }
     },
-    "3": {
-      "id": "3",
-      "parentId": "2",
+    "9": {
+      "id": "9",
+      "parentId": "6",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "EventStream"
         }
       }
     },
-    "4": {
-      "id": "4",
-      "parentId": "1",
-      "data": {
-        "@effection/attributes": {
-          "name": "SSEServer",
-          "port": 41000
-        }
-      }
-    },
-    "31": {
-      "id": "31",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "39": {
-      "id": "39",
-      "parentId": "32",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "40": {
-      "id": "40",
-      "parentId": "32",
+    "12": {
+      "id": "12",
+      "parentId": "11",
       "data": {}
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "42": {
-      "id": "42",
-      "parentId": "4",
-      "data": {
-        "@effection/attributes": {
-          "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
-        }
-      }
-    },
-    "43": {
-      "id": "43",
-      "parentId": "42",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "44": {
-      "id": "44",
-      "parentId": "43",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
+    "14": {
+      "id": "14",
+      "parentId": "13",
       "data": {}
     },
-    "46": {
-      "id": "46",
-      "parentId": "43",
-      "data": {}
-    }
-  },
-  {
-    "0": {
-      "id": "0",
+    "15": {
+      "id": "15",
+      "parentId": "12",
       "data": {
         "@effection/attributes": {
-          "name": "Global"
+          "name": "EventStream"
         }
       }
     },
-    "1": {
-      "id": "1",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Inspector"
-        }
-      }
-    },
-    "2": {
-      "id": "2",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "anonymous"
-        }
-      }
-    },
-    "3": {
-      "id": "3",
-      "parentId": "2",
-      "data": {
-        "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
-        }
-      }
-    },
-    "4": {
-      "id": "4",
-      "parentId": "1",
-      "data": {
-        "@effection/attributes": {
-          "name": "SSEServer",
-          "port": 41000
-        }
-      }
-    },
-    "31": {
-      "id": "31",
-      "parentId": "4",
-      "data": {
-        "@effection/attributes": {
-          "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
-        }
-      }
-    },
-    "32": {
-      "id": "32",
-      "parentId": "31",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "39": {
-      "id": "39",
-      "parentId": "32",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
-    },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
-    },
-    "42": {
-      "id": "42",
-      "parentId": "4",
-      "data": {
-        "@effection/attributes": {
-          "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
-        }
-      }
-    },
-    "43": {
-      "id": "43",
-      "parentId": "42",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "44": {
-      "id": "44",
-      "parentId": "43",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
-      "data": {}
-    },
-    "46": {
-      "id": "46",
-      "parentId": "43",
-      "data": {}
-    },
-    "47": {
-      "id": "47",
+    "16": {
+      "id": "16",
       "parentId": "3",
       "data": {}
     }
@@ -1428,8 +1071,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -1443,91 +1086,95 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "44": {
-      "id": "44",
-      "parentId": "43",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
+    "12": {
+      "id": "12",
+      "parentId": "11",
       "data": {}
     },
-    "46": {
-      "id": "46",
-      "parentId": "43",
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "47": {
-      "id": "47",
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    },
+    "15": {
+      "id": "15",
+      "parentId": "12",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "16": {
+      "id": "16",
       "parentId": "3",
       "data": {}
     },
-    "48": {
-      "id": "48",
+    "17": {
+      "id": "17",
       "parentId": "3",
       "data": {}
     }
@@ -1564,8 +1211,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -1579,96 +1226,100 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "44": {
-      "id": "44",
-      "parentId": "43",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
+    "12": {
+      "id": "12",
+      "parentId": "11",
       "data": {}
     },
-    "46": {
-      "id": "46",
-      "parentId": "43",
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "47": {
-      "id": "47",
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    },
+    "15": {
+      "id": "15",
+      "parentId": "12",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "16": {
+      "id": "16",
       "parentId": "3",
       "data": {}
     },
-    "48": {
-      "id": "48",
+    "17": {
+      "id": "17",
       "parentId": "3",
       "data": {}
     },
-    "49": {
-      "id": "49",
+    "18": {
+      "id": "18",
       "parentId": "3",
       "data": {}
     }
@@ -1705,8 +1356,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -1720,101 +1371,105 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
+    "12": {
+      "id": "12",
+      "parentId": "11",
+      "data": {}
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
+      "data": {}
+    },
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    },
+    "15": {
+      "id": "15",
+      "parentId": "12",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "EventStream"
         }
       }
     },
-    "44": {
-      "id": "44",
-      "parentId": "43",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
-      "data": {}
-    },
-    "46": {
-      "id": "46",
-      "parentId": "43",
-      "data": {}
-    },
-    "47": {
-      "id": "47",
+    "16": {
+      "id": "16",
       "parentId": "3",
       "data": {}
     },
-    "48": {
-      "id": "48",
+    "17": {
+      "id": "17",
       "parentId": "3",
       "data": {}
     },
-    "49": {
-      "id": "49",
+    "18": {
+      "id": "18",
       "parentId": "3",
       "data": {}
     },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {}
     }
@@ -1851,8 +1506,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -1866,106 +1521,110 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
+    "12": {
+      "id": "12",
+      "parentId": "11",
+      "data": {}
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
+      "data": {}
+    },
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    },
+    "15": {
+      "id": "15",
+      "parentId": "12",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "EventStream"
         }
       }
     },
-    "44": {
-      "id": "44",
-      "parentId": "43",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
-      "data": {}
-    },
-    "46": {
-      "id": "46",
-      "parentId": "43",
-      "data": {}
-    },
-    "47": {
-      "id": "47",
+    "16": {
+      "id": "16",
       "parentId": "3",
       "data": {}
     },
-    "48": {
-      "id": "48",
+    "17": {
+      "id": "17",
       "parentId": "3",
       "data": {}
     },
-    "49": {
-      "id": "49",
+    "18": {
+      "id": "18",
       "parentId": "3",
       "data": {}
     },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {}
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {}
     }
@@ -2002,8 +1661,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -2017,111 +1676,115 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
+    "12": {
+      "id": "12",
+      "parentId": "11",
+      "data": {}
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
+      "data": {}
+    },
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    },
+    "15": {
+      "id": "15",
+      "parentId": "12",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "EventStream"
         }
       }
     },
-    "44": {
-      "id": "44",
-      "parentId": "43",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
-      "data": {}
-    },
-    "46": {
-      "id": "46",
-      "parentId": "43",
-      "data": {}
-    },
-    "47": {
-      "id": "47",
+    "16": {
+      "id": "16",
       "parentId": "3",
       "data": {}
     },
-    "48": {
-      "id": "48",
+    "17": {
+      "id": "17",
       "parentId": "3",
       "data": {}
     },
-    "49": {
-      "id": "49",
+    "18": {
+      "id": "18",
       "parentId": "3",
       "data": {}
     },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {}
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {}
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {}
     }
@@ -2158,8 +1821,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -2173,116 +1836,120 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
+    "12": {
+      "id": "12",
+      "parentId": "11",
+      "data": {}
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
+      "data": {}
+    },
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    },
+    "15": {
+      "id": "15",
+      "parentId": "12",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "EventStream"
         }
       }
     },
-    "44": {
-      "id": "44",
-      "parentId": "43",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
-      "data": {}
-    },
-    "46": {
-      "id": "46",
-      "parentId": "43",
-      "data": {}
-    },
-    "47": {
-      "id": "47",
+    "16": {
+      "id": "16",
       "parentId": "3",
       "data": {}
     },
-    "48": {
-      "id": "48",
+    "17": {
+      "id": "17",
       "parentId": "3",
       "data": {}
     },
-    "49": {
-      "id": "49",
+    "18": {
+      "id": "18",
       "parentId": "3",
       "data": {}
     },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {}
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {}
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {}
     },
-    "53": {
-      "id": "53",
+    "22": {
+      "id": "22",
       "parentId": "3",
       "data": {}
     }
@@ -2319,8 +1986,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -2334,121 +2001,125 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
+    "12": {
+      "id": "12",
+      "parentId": "11",
+      "data": {}
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
+      "data": {}
+    },
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    },
+    "15": {
+      "id": "15",
+      "parentId": "12",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "EventStream"
         }
       }
     },
-    "44": {
-      "id": "44",
-      "parentId": "43",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
-      "data": {}
-    },
-    "46": {
-      "id": "46",
-      "parentId": "43",
-      "data": {}
-    },
-    "47": {
-      "id": "47",
+    "16": {
+      "id": "16",
       "parentId": "3",
       "data": {}
     },
-    "48": {
-      "id": "48",
+    "17": {
+      "id": "17",
       "parentId": "3",
       "data": {}
     },
-    "49": {
-      "id": "49",
+    "18": {
+      "id": "18",
       "parentId": "3",
       "data": {}
     },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {}
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {}
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {}
     },
-    "53": {
-      "id": "53",
+    "22": {
+      "id": "22",
       "parentId": "3",
       "data": {}
     },
-    "54": {
-      "id": "54",
+    "23": {
+      "id": "23",
       "parentId": "3",
       "data": {}
     }
@@ -2485,8 +2156,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -2500,126 +2171,130 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
+    "12": {
+      "id": "12",
+      "parentId": "11",
+      "data": {}
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
+      "data": {}
+    },
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    },
+    "15": {
+      "id": "15",
+      "parentId": "12",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "EventStream"
         }
       }
     },
-    "44": {
-      "id": "44",
-      "parentId": "43",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
-      "data": {}
-    },
-    "46": {
-      "id": "46",
-      "parentId": "43",
-      "data": {}
-    },
-    "47": {
-      "id": "47",
+    "16": {
+      "id": "16",
       "parentId": "3",
       "data": {}
     },
-    "48": {
-      "id": "48",
+    "17": {
+      "id": "17",
       "parentId": "3",
       "data": {}
     },
-    "49": {
-      "id": "49",
+    "18": {
+      "id": "18",
       "parentId": "3",
       "data": {}
     },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {}
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {}
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {}
     },
-    "53": {
-      "id": "53",
+    "22": {
+      "id": "22",
       "parentId": "3",
       "data": {}
     },
-    "54": {
-      "id": "54",
+    "23": {
+      "id": "23",
       "parentId": "3",
       "data": {}
     },
-    "55": {
-      "id": "55",
+    "24": {
+      "id": "24",
       "parentId": "3",
       "data": {}
     }
@@ -2656,8 +2331,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -2671,131 +2346,135 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
+    "12": {
+      "id": "12",
+      "parentId": "11",
+      "data": {}
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
+      "data": {}
+    },
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    },
+    "15": {
+      "id": "15",
+      "parentId": "12",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "EventStream"
         }
       }
     },
-    "44": {
-      "id": "44",
-      "parentId": "43",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
-      "data": {}
-    },
-    "46": {
-      "id": "46",
-      "parentId": "43",
-      "data": {}
-    },
-    "47": {
-      "id": "47",
+    "16": {
+      "id": "16",
       "parentId": "3",
       "data": {}
     },
-    "48": {
-      "id": "48",
+    "17": {
+      "id": "17",
       "parentId": "3",
       "data": {}
     },
-    "49": {
-      "id": "49",
+    "18": {
+      "id": "18",
       "parentId": "3",
       "data": {}
     },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {}
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {}
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {}
     },
-    "53": {
-      "id": "53",
+    "22": {
+      "id": "22",
       "parentId": "3",
       "data": {}
     },
-    "54": {
-      "id": "54",
+    "23": {
+      "id": "23",
       "parentId": "3",
       "data": {}
     },
-    "55": {
-      "id": "55",
+    "24": {
+      "id": "24",
       "parentId": "3",
       "data": {}
     },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {}
     }
@@ -2832,8 +2511,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -2847,86 +2526,90 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "44": {
-      "id": "44",
-      "parentId": "43",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
+    "12": {
+      "id": "12",
+      "parentId": "11",
       "data": {}
     },
-    "46": {
-      "id": "46",
-      "parentId": "43",
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "47": {
-      "id": "47",
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    },
+    "15": {
+      "id": "15",
+      "parentId": "12",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "16": {
+      "id": "16",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -2935,48 +2618,48 @@
         }
       }
     },
-    "48": {
-      "id": "48",
+    "17": {
+      "id": "17",
       "parentId": "3",
       "data": {}
     },
-    "49": {
-      "id": "49",
+    "18": {
+      "id": "18",
       "parentId": "3",
       "data": {}
     },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {}
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {}
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {}
     },
-    "53": {
-      "id": "53",
+    "22": {
+      "id": "22",
       "parentId": "3",
       "data": {}
     },
-    "54": {
-      "id": "54",
+    "23": {
+      "id": "23",
       "parentId": "3",
       "data": {}
     },
-    "55": {
-      "id": "55",
+    "24": {
+      "id": "24",
       "parentId": "3",
       "data": {}
     },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {}
     }
@@ -3013,8 +2696,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -3028,86 +2711,90 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "44": {
-      "id": "44",
-      "parentId": "43",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
+    "12": {
+      "id": "12",
+      "parentId": "11",
       "data": {}
     },
-    "46": {
-      "id": "46",
-      "parentId": "43",
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "47": {
-      "id": "47",
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    },
+    "15": {
+      "id": "15",
+      "parentId": "12",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "16": {
+      "id": "16",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -3116,8 +2803,8 @@
         }
       }
     },
-    "48": {
-      "id": "48",
+    "17": {
+      "id": "17",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -3126,43 +2813,43 @@
         }
       }
     },
-    "49": {
-      "id": "49",
+    "18": {
+      "id": "18",
       "parentId": "3",
       "data": {}
     },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {}
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {}
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {}
     },
-    "53": {
-      "id": "53",
+    "22": {
+      "id": "22",
       "parentId": "3",
       "data": {}
     },
-    "54": {
-      "id": "54",
+    "23": {
+      "id": "23",
       "parentId": "3",
       "data": {}
     },
-    "55": {
-      "id": "55",
+    "24": {
+      "id": "24",
       "parentId": "3",
       "data": {}
     },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {}
     }
@@ -3199,8 +2886,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -3214,86 +2901,90 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "44": {
-      "id": "44",
-      "parentId": "43",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
+    "12": {
+      "id": "12",
+      "parentId": "11",
       "data": {}
     },
-    "46": {
-      "id": "46",
-      "parentId": "43",
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "47": {
-      "id": "47",
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    },
+    "15": {
+      "id": "15",
+      "parentId": "12",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "16": {
+      "id": "16",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -3302,8 +2993,8 @@
         }
       }
     },
-    "48": {
-      "id": "48",
+    "17": {
+      "id": "17",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -3312,8 +3003,8 @@
         }
       }
     },
-    "49": {
-      "id": "49",
+    "18": {
+      "id": "18",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -3322,38 +3013,38 @@
         }
       }
     },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {}
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {}
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {}
     },
-    "53": {
-      "id": "53",
+    "22": {
+      "id": "22",
       "parentId": "3",
       "data": {}
     },
-    "54": {
-      "id": "54",
+    "23": {
+      "id": "23",
       "parentId": "3",
       "data": {}
     },
-    "55": {
-      "id": "55",
+    "24": {
+      "id": "24",
       "parentId": "3",
       "data": {}
     },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {}
     }
@@ -3390,8 +3081,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -3405,86 +3096,90 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "44": {
-      "id": "44",
-      "parentId": "43",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
+    "12": {
+      "id": "12",
+      "parentId": "11",
       "data": {}
     },
-    "46": {
-      "id": "46",
-      "parentId": "43",
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "47": {
-      "id": "47",
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    },
+    "15": {
+      "id": "15",
+      "parentId": "12",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "16": {
+      "id": "16",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -3493,8 +3188,8 @@
         }
       }
     },
-    "48": {
-      "id": "48",
+    "17": {
+      "id": "17",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -3503,8 +3198,8 @@
         }
       }
     },
-    "49": {
-      "id": "49",
+    "18": {
+      "id": "18",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -3513,8 +3208,8 @@
         }
       }
     },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -3523,33 +3218,33 @@
         }
       }
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {}
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {}
     },
-    "53": {
-      "id": "53",
+    "22": {
+      "id": "22",
       "parentId": "3",
       "data": {}
     },
-    "54": {
-      "id": "54",
+    "23": {
+      "id": "23",
       "parentId": "3",
       "data": {}
     },
-    "55": {
-      "id": "55",
+    "24": {
+      "id": "24",
       "parentId": "3",
       "data": {}
     },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {}
     }
@@ -3586,8 +3281,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -3601,86 +3296,90 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "44": {
-      "id": "44",
-      "parentId": "43",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
+    "12": {
+      "id": "12",
+      "parentId": "11",
       "data": {}
     },
-    "46": {
-      "id": "46",
-      "parentId": "43",
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "47": {
-      "id": "47",
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    },
+    "15": {
+      "id": "15",
+      "parentId": "12",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "16": {
+      "id": "16",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -3689,8 +3388,8 @@
         }
       }
     },
-    "48": {
-      "id": "48",
+    "17": {
+      "id": "17",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -3699,8 +3398,8 @@
         }
       }
     },
-    "49": {
-      "id": "49",
+    "18": {
+      "id": "18",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -3709,8 +3408,8 @@
         }
       }
     },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -3719,8 +3418,8 @@
         }
       }
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -3729,28 +3428,28 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {}
     },
-    "53": {
-      "id": "53",
+    "22": {
+      "id": "22",
       "parentId": "3",
       "data": {}
     },
-    "54": {
-      "id": "54",
+    "23": {
+      "id": "23",
       "parentId": "3",
       "data": {}
     },
-    "55": {
-      "id": "55",
+    "24": {
+      "id": "24",
       "parentId": "3",
       "data": {}
     },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {}
     }
@@ -3787,8 +3486,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -3802,86 +3501,90 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "44": {
-      "id": "44",
-      "parentId": "43",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
+    "12": {
+      "id": "12",
+      "parentId": "11",
       "data": {}
     },
-    "46": {
-      "id": "46",
-      "parentId": "43",
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "47": {
-      "id": "47",
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    },
+    "15": {
+      "id": "15",
+      "parentId": "12",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "16": {
+      "id": "16",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -3890,8 +3593,8 @@
         }
       }
     },
-    "48": {
-      "id": "48",
+    "17": {
+      "id": "17",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -3900,8 +3603,8 @@
         }
       }
     },
-    "49": {
-      "id": "49",
+    "18": {
+      "id": "18",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -3910,8 +3613,8 @@
         }
       }
     },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -3920,8 +3623,8 @@
         }
       }
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -3930,8 +3633,8 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -3940,23 +3643,23 @@
         }
       }
     },
-    "53": {
-      "id": "53",
+    "22": {
+      "id": "22",
       "parentId": "3",
       "data": {}
     },
-    "54": {
-      "id": "54",
+    "23": {
+      "id": "23",
       "parentId": "3",
       "data": {}
     },
-    "55": {
-      "id": "55",
+    "24": {
+      "id": "24",
       "parentId": "3",
       "data": {}
     },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {}
     }
@@ -3993,8 +3696,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -4008,86 +3711,90 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "44": {
-      "id": "44",
-      "parentId": "43",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
+    "12": {
+      "id": "12",
+      "parentId": "11",
       "data": {}
     },
-    "46": {
-      "id": "46",
-      "parentId": "43",
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "47": {
-      "id": "47",
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    },
+    "15": {
+      "id": "15",
+      "parentId": "12",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "16": {
+      "id": "16",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4096,8 +3803,8 @@
         }
       }
     },
-    "48": {
-      "id": "48",
+    "17": {
+      "id": "17",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4106,8 +3813,8 @@
         }
       }
     },
-    "49": {
-      "id": "49",
+    "18": {
+      "id": "18",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4116,8 +3823,8 @@
         }
       }
     },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4126,8 +3833,8 @@
         }
       }
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4136,8 +3843,8 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4146,8 +3853,8 @@
         }
       }
     },
-    "53": {
-      "id": "53",
+    "22": {
+      "id": "22",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4156,18 +3863,18 @@
         }
       }
     },
-    "54": {
-      "id": "54",
+    "23": {
+      "id": "23",
       "parentId": "3",
       "data": {}
     },
-    "55": {
-      "id": "55",
+    "24": {
+      "id": "24",
       "parentId": "3",
       "data": {}
     },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {}
     }
@@ -4204,8 +3911,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -4219,86 +3926,90 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "44": {
-      "id": "44",
-      "parentId": "43",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
+    "12": {
+      "id": "12",
+      "parentId": "11",
       "data": {}
     },
-    "46": {
-      "id": "46",
-      "parentId": "43",
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "47": {
-      "id": "47",
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    },
+    "15": {
+      "id": "15",
+      "parentId": "12",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "16": {
+      "id": "16",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4307,8 +4018,8 @@
         }
       }
     },
-    "48": {
-      "id": "48",
+    "17": {
+      "id": "17",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4317,8 +4028,8 @@
         }
       }
     },
-    "49": {
-      "id": "49",
+    "18": {
+      "id": "18",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4327,8 +4038,8 @@
         }
       }
     },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4337,8 +4048,8 @@
         }
       }
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4347,8 +4058,8 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4357,8 +4068,8 @@
         }
       }
     },
-    "53": {
-      "id": "53",
+    "22": {
+      "id": "22",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4367,8 +4078,8 @@
         }
       }
     },
-    "54": {
-      "id": "54",
+    "23": {
+      "id": "23",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4377,13 +4088,13 @@
         }
       }
     },
-    "55": {
-      "id": "55",
+    "24": {
+      "id": "24",
       "parentId": "3",
       "data": {}
     },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {}
     }
@@ -4420,8 +4131,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -4435,86 +4146,90 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "44": {
-      "id": "44",
-      "parentId": "43",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
+    "12": {
+      "id": "12",
+      "parentId": "11",
       "data": {}
     },
-    "46": {
-      "id": "46",
-      "parentId": "43",
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "47": {
-      "id": "47",
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    },
+    "15": {
+      "id": "15",
+      "parentId": "12",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "16": {
+      "id": "16",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4523,8 +4238,8 @@
         }
       }
     },
-    "48": {
-      "id": "48",
+    "17": {
+      "id": "17",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4533,8 +4248,8 @@
         }
       }
     },
-    "49": {
-      "id": "49",
+    "18": {
+      "id": "18",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4543,8 +4258,8 @@
         }
       }
     },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4553,8 +4268,8 @@
         }
       }
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4563,8 +4278,8 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4573,8 +4288,8 @@
         }
       }
     },
-    "53": {
-      "id": "53",
+    "22": {
+      "id": "22",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4583,8 +4298,8 @@
         }
       }
     },
-    "54": {
-      "id": "54",
+    "23": {
+      "id": "23",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4593,8 +4308,8 @@
         }
       }
     },
-    "55": {
-      "id": "55",
+    "24": {
+      "id": "24",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4603,8 +4318,8 @@
         }
       }
     },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {}
     }
@@ -4641,8 +4356,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -4656,86 +4371,90 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "44": {
-      "id": "44",
-      "parentId": "43",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
+    "12": {
+      "id": "12",
+      "parentId": "11",
       "data": {}
     },
-    "46": {
-      "id": "46",
-      "parentId": "43",
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "47": {
-      "id": "47",
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    },
+    "15": {
+      "id": "15",
+      "parentId": "12",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "16": {
+      "id": "16",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4744,8 +4463,8 @@
         }
       }
     },
-    "48": {
-      "id": "48",
+    "17": {
+      "id": "17",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4754,8 +4473,8 @@
         }
       }
     },
-    "49": {
-      "id": "49",
+    "18": {
+      "id": "18",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4764,8 +4483,8 @@
         }
       }
     },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4774,8 +4493,8 @@
         }
       }
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4784,8 +4503,8 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4794,8 +4513,8 @@
         }
       }
     },
-    "53": {
-      "id": "53",
+    "22": {
+      "id": "22",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4804,8 +4523,8 @@
         }
       }
     },
-    "54": {
-      "id": "54",
+    "23": {
+      "id": "23",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4814,8 +4533,8 @@
         }
       }
     },
-    "55": {
-      "id": "55",
+    "24": {
+      "id": "24",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4824,8 +4543,8 @@
         }
       }
     },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4867,8 +4586,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -4882,86 +4601,90 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "44": {
-      "id": "44",
-      "parentId": "43",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
+    "12": {
+      "id": "12",
+      "parentId": "11",
       "data": {}
     },
-    "46": {
-      "id": "46",
-      "parentId": "43",
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "47": {
-      "id": "47",
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    },
+    "15": {
+      "id": "15",
+      "parentId": "12",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "16": {
+      "id": "16",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4970,8 +4693,8 @@
         }
       }
     },
-    "48": {
-      "id": "48",
+    "17": {
+      "id": "17",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4980,8 +4703,8 @@
         }
       }
     },
-    "49": {
-      "id": "49",
+    "18": {
+      "id": "18",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -4990,8 +4713,8 @@
         }
       }
     },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5000,8 +4723,8 @@
         }
       }
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5010,8 +4733,8 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5020,8 +4743,8 @@
         }
       }
     },
-    "53": {
-      "id": "53",
+    "22": {
+      "id": "22",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5030,8 +4753,8 @@
         }
       }
     },
-    "54": {
-      "id": "54",
+    "23": {
+      "id": "23",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5040,8 +4763,8 @@
         }
       }
     },
-    "55": {
-      "id": "55",
+    "24": {
+      "id": "24",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5050,8 +4773,8 @@
         }
       }
     },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5093,8 +4816,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -5108,77 +4831,81 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
+    "12": {
+      "id": "12",
+      "parentId": "11",
       "data": {}
     },
-    "46": {
-      "id": "46",
-      "parentId": "43",
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "47": {
-      "id": "47",
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    },
+    "16": {
+      "id": "16",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5187,8 +4914,8 @@
         }
       }
     },
-    "48": {
-      "id": "48",
+    "17": {
+      "id": "17",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5197,8 +4924,8 @@
         }
       }
     },
-    "49": {
-      "id": "49",
+    "18": {
+      "id": "18",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5207,8 +4934,8 @@
         }
       }
     },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5217,8 +4944,8 @@
         }
       }
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5227,8 +4954,8 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5237,8 +4964,8 @@
         }
       }
     },
-    "53": {
-      "id": "53",
+    "22": {
+      "id": "22",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5247,8 +4974,8 @@
         }
       }
     },
-    "54": {
-      "id": "54",
+    "23": {
+      "id": "23",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5257,8 +4984,8 @@
         }
       }
     },
-    "55": {
-      "id": "55",
+    "24": {
+      "id": "24",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5267,8 +4994,8 @@
         }
       }
     },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5310,8 +5037,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -5325,77 +5052,81 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
+    "12": {
+      "id": "12",
+      "parentId": "11",
       "data": {}
     },
-    "46": {
-      "id": "46",
-      "parentId": "43",
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "47": {
-      "id": "47",
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    },
+    "16": {
+      "id": "16",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5404,8 +5135,8 @@
         }
       }
     },
-    "48": {
-      "id": "48",
+    "17": {
+      "id": "17",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5414,8 +5145,8 @@
         }
       }
     },
-    "49": {
-      "id": "49",
+    "18": {
+      "id": "18",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5424,8 +5155,8 @@
         }
       }
     },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5434,8 +5165,8 @@
         }
       }
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5444,8 +5175,8 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5454,8 +5185,8 @@
         }
       }
     },
-    "53": {
-      "id": "53",
+    "22": {
+      "id": "22",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5464,8 +5195,8 @@
         }
       }
     },
-    "54": {
-      "id": "54",
+    "23": {
+      "id": "23",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5474,8 +5205,8 @@
         }
       }
     },
-    "55": {
-      "id": "55",
+    "24": {
+      "id": "24",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5484,8 +5215,8 @@
         }
       }
     },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5527,8 +5258,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -5542,72 +5273,76 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "47": {
-      "id": "47",
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    },
+    "16": {
+      "id": "16",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5616,8 +5351,8 @@
         }
       }
     },
-    "48": {
-      "id": "48",
+    "17": {
+      "id": "17",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5626,8 +5361,8 @@
         }
       }
     },
-    "49": {
-      "id": "49",
+    "18": {
+      "id": "18",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5636,8 +5371,8 @@
         }
       }
     },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5646,8 +5381,8 @@
         }
       }
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5656,8 +5391,8 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5666,8 +5401,8 @@
         }
       }
     },
-    "53": {
-      "id": "53",
+    "22": {
+      "id": "22",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5676,8 +5411,8 @@
         }
       }
     },
-    "54": {
-      "id": "54",
+    "23": {
+      "id": "23",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5686,8 +5421,8 @@
         }
       }
     },
-    "55": {
-      "id": "55",
+    "24": {
+      "id": "24",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5696,8 +5431,8 @@
         }
       }
     },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5739,8 +5474,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -5754,72 +5489,76 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "47": {
-      "id": "47",
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    },
+    "16": {
+      "id": "16",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5828,8 +5567,8 @@
         }
       }
     },
-    "48": {
-      "id": "48",
+    "17": {
+      "id": "17",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5838,8 +5577,8 @@
         }
       }
     },
-    "49": {
-      "id": "49",
+    "18": {
+      "id": "18",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5848,8 +5587,8 @@
         }
       }
     },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5858,8 +5597,8 @@
         }
       }
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5868,8 +5607,8 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5878,8 +5617,8 @@
         }
       }
     },
-    "53": {
-      "id": "53",
+    "22": {
+      "id": "22",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5888,8 +5627,8 @@
         }
       }
     },
-    "54": {
-      "id": "54",
+    "23": {
+      "id": "23",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5898,8 +5637,8 @@
         }
       }
     },
-    "55": {
-      "id": "55",
+    "24": {
+      "id": "24",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5908,8 +5647,8 @@
         }
       }
     },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -5917,11 +5656,6 @@
           "number": 10
         }
       }
-    },
-    "57": {
-      "id": "57",
-      "parentId": "43",
-      "data": {}
     }
   },
   {
@@ -5956,8 +5690,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -5971,72 +5705,76 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "47": {
-      "id": "47",
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    },
+    "16": {
+      "id": "16",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6045,8 +5783,8 @@
         }
       }
     },
-    "48": {
-      "id": "48",
+    "17": {
+      "id": "17",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6055,18 +5793,8 @@
         }
       }
     },
-    "49": {
-      "id": "49",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 3
-        }
-      }
-    },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6075,8 +5803,8 @@
         }
       }
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6085,8 +5813,8 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6095,8 +5823,8 @@
         }
       }
     },
-    "53": {
-      "id": "53",
+    "22": {
+      "id": "22",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6105,8 +5833,8 @@
         }
       }
     },
-    "54": {
-      "id": "54",
+    "23": {
+      "id": "23",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6115,8 +5843,8 @@
         }
       }
     },
-    "55": {
-      "id": "55",
+    "24": {
+      "id": "24",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6125,8 +5853,8 @@
         }
       }
     },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6134,16 +5862,6 @@
           "number": 10
         }
       }
-    },
-    "57": {
-      "id": "57",
-      "parentId": "43",
-      "data": {}
-    },
-    "58": {
-      "id": "58",
-      "parentId": "43",
-      "data": {}
     }
   },
   {
@@ -6178,8 +5896,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -6193,72 +5911,76 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "47": {
-      "id": "47",
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    },
+    "16": {
+      "id": "16",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6267,8 +5989,8 @@
         }
       }
     },
-    "48": {
-      "id": "48",
+    "17": {
+      "id": "17",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6277,18 +5999,8 @@
         }
       }
     },
-    "49": {
-      "id": "49",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 3
-        }
-      }
-    },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6297,8 +6009,8 @@
         }
       }
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6307,8 +6019,8 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6317,8 +6029,8 @@
         }
       }
     },
-    "53": {
-      "id": "53",
+    "22": {
+      "id": "22",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6327,8 +6039,8 @@
         }
       }
     },
-    "54": {
-      "id": "54",
+    "23": {
+      "id": "23",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6337,8 +6049,8 @@
         }
       }
     },
-    "55": {
-      "id": "55",
+    "24": {
+      "id": "24",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6347,8 +6059,8 @@
         }
       }
     },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6356,16 +6068,6 @@
           "number": 10
         }
       }
-    },
-    "57": {
-      "id": "57",
-      "parentId": "43",
-      "data": {}
-    },
-    "58": {
-      "id": "58",
-      "parentId": "43",
-      "data": {}
     }
   },
   {
@@ -6400,8 +6102,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -6415,82 +6117,76 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "47": {
-      "id": "47",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 1
-        }
-      }
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
     },
-    "48": {
-      "id": "48",
+    "17": {
+      "id": "17",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6499,18 +6195,8 @@
         }
       }
     },
-    "49": {
-      "id": "49",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 3
-        }
-      }
-    },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6519,8 +6205,8 @@
         }
       }
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6529,8 +6215,8 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6539,8 +6225,8 @@
         }
       }
     },
-    "53": {
-      "id": "53",
+    "22": {
+      "id": "22",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6549,8 +6235,8 @@
         }
       }
     },
-    "54": {
-      "id": "54",
+    "23": {
+      "id": "23",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6559,8 +6245,8 @@
         }
       }
     },
-    "55": {
-      "id": "55",
+    "24": {
+      "id": "24",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6569,8 +6255,8 @@
         }
       }
     },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6578,16 +6264,6 @@
           "number": 10
         }
       }
-    },
-    "57": {
-      "id": "57",
-      "parentId": "43",
-      "data": {}
-    },
-    "58": {
-      "id": "58",
-      "parentId": "43",
-      "data": {}
     }
   },
   {
@@ -6622,8 +6298,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -6637,82 +6313,76 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "47": {
-      "id": "47",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 1
-        }
-      }
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
     },
-    "48": {
-      "id": "48",
+    "17": {
+      "id": "17",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6721,18 +6391,8 @@
         }
       }
     },
-    "49": {
-      "id": "49",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 3
-        }
-      }
-    },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6741,8 +6401,8 @@
         }
       }
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6751,8 +6411,8 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6761,8 +6421,8 @@
         }
       }
     },
-    "53": {
-      "id": "53",
+    "22": {
+      "id": "22",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6771,8 +6431,8 @@
         }
       }
     },
-    "54": {
-      "id": "54",
+    "23": {
+      "id": "23",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6781,8 +6441,8 @@
         }
       }
     },
-    "55": {
-      "id": "55",
+    "24": {
+      "id": "24",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6791,8 +6451,8 @@
         }
       }
     },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6800,16 +6460,6 @@
           "number": 10
         }
       }
-    },
-    "57": {
-      "id": "57",
-      "parentId": "43",
-      "data": {}
-    },
-    "58": {
-      "id": "58",
-      "parentId": "43",
-      "data": {}
     }
   },
   {
@@ -6844,8 +6494,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -6859,82 +6509,76 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "47": {
-      "id": "47",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 1
-        }
-      }
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
     },
-    "48": {
-      "id": "48",
+    "17": {
+      "id": "17",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6943,18 +6587,8 @@
         }
       }
     },
-    "49": {
-      "id": "49",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 3
-        }
-      }
-    },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6963,8 +6597,8 @@
         }
       }
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6973,8 +6607,8 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6983,8 +6617,8 @@
         }
       }
     },
-    "53": {
-      "id": "53",
+    "22": {
+      "id": "22",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -6993,8 +6627,8 @@
         }
       }
     },
-    "54": {
-      "id": "54",
+    "23": {
+      "id": "23",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -7003,8 +6637,8 @@
         }
       }
     },
-    "55": {
-      "id": "55",
+    "24": {
+      "id": "24",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -7013,8 +6647,8 @@
         }
       }
     },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -7022,16 +6656,6 @@
           "number": 10
         }
       }
-    },
-    "57": {
-      "id": "57",
-      "parentId": "43",
-      "data": {}
-    },
-    "58": {
-      "id": "58",
-      "parentId": "43",
-      "data": {}
     }
   },
   {
@@ -7066,8 +6690,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -7081,82 +6705,76 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "47": {
-      "id": "47",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 1
-        }
-      }
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
     },
-    "48": {
-      "id": "48",
+    "17": {
+      "id": "17",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -7165,18 +6783,8 @@
         }
       }
     },
-    "49": {
-      "id": "49",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 3
-        }
-      }
-    },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -7185,8 +6793,8 @@
         }
       }
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -7195,8 +6803,8 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -7205,8 +6813,8 @@
         }
       }
     },
-    "53": {
-      "id": "53",
+    "22": {
+      "id": "22",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -7215,8 +6823,8 @@
         }
       }
     },
-    "54": {
-      "id": "54",
+    "23": {
+      "id": "23",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -7225,8 +6833,8 @@
         }
       }
     },
-    "55": {
-      "id": "55",
+    "24": {
+      "id": "24",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -7235,8 +6843,8 @@
         }
       }
     },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -7244,16 +6852,6 @@
           "number": 10
         }
       }
-    },
-    "57": {
-      "id": "57",
-      "parentId": "43",
-      "data": {}
-    },
-    "58": {
-      "id": "58",
-      "parentId": "43",
-      "data": {}
     }
   },
   {
@@ -7288,8 +6886,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -7303,82 +6901,76 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "45": {
-      "id": "45",
-      "parentId": "43",
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "47": {
-      "id": "47",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 1
-        }
-      }
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
     },
-    "48": {
-      "id": "48",
+    "17": {
+      "id": "17",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -7387,18 +6979,8 @@
         }
       }
     },
-    "49": {
-      "id": "49",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 3
-        }
-      }
-    },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -7407,8 +6989,8 @@
         }
       }
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -7417,8 +6999,8 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -7427,8 +7009,8 @@
         }
       }
     },
-    "53": {
-      "id": "53",
+    "22": {
+      "id": "22",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -7437,8 +7019,8 @@
         }
       }
     },
-    "54": {
-      "id": "54",
+    "23": {
+      "id": "23",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -7447,8 +7029,8 @@
         }
       }
     },
-    "55": {
-      "id": "55",
+    "24": {
+      "id": "24",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -7457,8 +7039,8 @@
         }
       }
     },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -7466,11 +7048,6 @@
           "number": 10
         }
       }
-    },
-    "57": {
-      "id": "57",
-      "parentId": "43",
-      "data": {}
     }
   },
   {
@@ -7505,8 +7082,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -7520,97 +7097,76 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
+    "13": {
+      "id": "13",
+      "parentId": "11",
+      "data": {}
     },
-    "47": {
-      "id": "47",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 1
-        }
-      }
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
     },
-    "48": {
-      "id": "48",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 2
-        }
-      }
-    },
-    "49": {
-      "id": "49",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 3
-        }
-      }
-    },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -7619,8 +7175,8 @@
         }
       }
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -7629,8 +7185,8 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -7639,8 +7195,8 @@
         }
       }
     },
-    "53": {
-      "id": "53",
+    "22": {
+      "id": "22",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -7649,8 +7205,8 @@
         }
       }
     },
-    "54": {
-      "id": "54",
+    "23": {
+      "id": "23",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -7659,8 +7215,8 @@
         }
       }
     },
-    "55": {
-      "id": "55",
+    "24": {
+      "id": "24",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -7669,8 +7225,8 @@
         }
       }
     },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -7678,11 +7234,6 @@
           "number": 10
         }
       }
-    },
-    "57": {
-      "id": "57",
-      "parentId": "43",
-      "data": {}
     }
   },
   {
@@ -7717,8 +7268,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -7732,97 +7283,76 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
+    "13": {
+      "id": "13",
+      "parentId": "11",
+      "data": {}
     },
-    "47": {
-      "id": "47",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 1
-        }
-      }
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
     },
-    "48": {
-      "id": "48",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 2
-        }
-      }
-    },
-    "49": {
-      "id": "49",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 3
-        }
-      }
-    },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -7831,8 +7361,8 @@
         }
       }
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -7841,8 +7371,8 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -7851,8 +7381,8 @@
         }
       }
     },
-    "53": {
-      "id": "53",
+    "22": {
+      "id": "22",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -7861,8 +7391,8 @@
         }
       }
     },
-    "54": {
-      "id": "54",
+    "23": {
+      "id": "23",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -7871,8 +7401,8 @@
         }
       }
     },
-    "55": {
-      "id": "55",
+    "24": {
+      "id": "24",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -7881,8 +7411,8 @@
         }
       }
     },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -7890,11 +7420,6 @@
           "number": 10
         }
       }
-    },
-    "57": {
-      "id": "57",
-      "parentId": "43",
-      "data": {}
     }
   },
   {
@@ -7929,8 +7454,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -7944,97 +7469,76 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
+    "13": {
+      "id": "13",
+      "parentId": "11",
+      "data": {}
     },
-    "47": {
-      "id": "47",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 1
-        }
-      }
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
     },
-    "48": {
-      "id": "48",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 2
-        }
-      }
-    },
-    "49": {
-      "id": "49",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 3
-        }
-      }
-    },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -8043,8 +7547,8 @@
         }
       }
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -8053,8 +7557,8 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -8063,18 +7567,8 @@
         }
       }
     },
-    "53": {
-      "id": "53",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 7
-        }
-      }
-    },
-    "54": {
-      "id": "54",
+    "23": {
+      "id": "23",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -8083,8 +7577,8 @@
         }
       }
     },
-    "55": {
-      "id": "55",
+    "24": {
+      "id": "24",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -8093,8 +7587,8 @@
         }
       }
     },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -8136,8 +7630,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -8151,97 +7645,76 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "43": {
-      "id": "43",
-      "parentId": "42",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
+    "13": {
+      "id": "13",
+      "parentId": "11",
+      "data": {}
     },
-    "47": {
-      "id": "47",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 1
-        }
-      }
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
     },
-    "48": {
-      "id": "48",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 2
-        }
-      }
-    },
-    "49": {
-      "id": "49",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 3
-        }
-      }
-    },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -8250,8 +7723,8 @@
         }
       }
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -8260,8 +7733,8 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -8270,18 +7743,8 @@
         }
       }
     },
-    "53": {
-      "id": "53",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 7
-        }
-      }
-    },
-    "54": {
-      "id": "54",
+    "23": {
+      "id": "23",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -8290,8 +7753,8 @@
         }
       }
     },
-    "55": {
-      "id": "55",
+    "24": {
+      "id": "24",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -8300,8 +7763,8 @@
         }
       }
     },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -8343,8 +7806,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -8358,88 +7821,76 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "47": {
-      "id": "47",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 1
-        }
-      }
+    "13": {
+      "id": "13",
+      "parentId": "11",
+      "data": {}
     },
-    "48": {
-      "id": "48",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 2
-        }
-      }
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
     },
-    "49": {
-      "id": "49",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 3
-        }
-      }
-    },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -8448,8 +7899,8 @@
         }
       }
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -8458,8 +7909,8 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -8468,28 +7919,8 @@
         }
       }
     },
-    "53": {
-      "id": "53",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 7
-        }
-      }
-    },
-    "54": {
-      "id": "54",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 8
-        }
-      }
-    },
-    "55": {
-      "id": "55",
+    "24": {
+      "id": "24",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -8498,8 +7929,8 @@
         }
       }
     },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -8541,8 +7972,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -8556,88 +7987,76 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     },
-    "42": {
-      "id": "42",
+    "11": {
+      "id": "11",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/play",
-          "method": "GET"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "47": {
-      "id": "47",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 1
-        }
-      }
+    "13": {
+      "id": "13",
+      "parentId": "11",
+      "data": {}
     },
-    "48": {
-      "id": "48",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 2
-        }
-      }
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
     },
-    "49": {
-      "id": "49",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 3
-        }
-      }
-    },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -8646,8 +8065,8 @@
         }
       }
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -8656,8 +8075,8 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -8666,28 +8085,8 @@
         }
       }
     },
-    "53": {
-      "id": "53",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 7
-        }
-      }
-    },
-    "54": {
-      "id": "54",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 8
-        }
-      }
-    },
-    "55": {
-      "id": "55",
+    "24": {
+      "id": "24",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -8696,8 +8095,8 @@
         }
       }
     },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -8739,8 +8138,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -8754,77 +8153,76 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "11": {
+      "id": "11",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
+    "14": {
+      "id": "14",
+      "parentId": "13",
       "data": {}
     },
-    "47": {
-      "id": "47",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 1
-        }
-      }
-    },
-    "48": {
-      "id": "48",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 2
-        }
-      }
-    },
-    "49": {
-      "id": "49",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 3
-        }
-      }
-    },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -8833,8 +8231,8 @@
         }
       }
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -8843,8 +8241,8 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -8853,28 +8251,8 @@
         }
       }
     },
-    "53": {
-      "id": "53",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 7
-        }
-      }
-    },
-    "54": {
-      "id": "54",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 8
-        }
-      }
-    },
-    "55": {
-      "id": "55",
+    "24": {
+      "id": "24",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -8883,8 +8261,8 @@
         }
       }
     },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -8926,8 +8304,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -8941,77 +8319,76 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "11": {
+      "id": "11",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
+    "14": {
+      "id": "14",
+      "parentId": "13",
       "data": {}
     },
-    "47": {
-      "id": "47",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 1
-        }
-      }
-    },
-    "48": {
-      "id": "48",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 2
-        }
-      }
-    },
-    "49": {
-      "id": "49",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 3
-        }
-      }
-    },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -9020,8 +8397,8 @@
         }
       }
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -9030,8 +8407,8 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -9040,28 +8417,8 @@
         }
       }
     },
-    "53": {
-      "id": "53",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 7
-        }
-      }
-    },
-    "54": {
-      "id": "54",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 8
-        }
-      }
-    },
-    "55": {
-      "id": "55",
+    "24": {
+      "id": "24",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -9070,8 +8427,8 @@
         }
       }
     },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -9113,8 +8470,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -9128,77 +8485,76 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "11": {
+      "id": "11",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
+    "14": {
+      "id": "14",
+      "parentId": "13",
       "data": {}
     },
-    "47": {
-      "id": "47",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 1
-        }
-      }
-    },
-    "48": {
-      "id": "48",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 2
-        }
-      }
-    },
-    "49": {
-      "id": "49",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 3
-        }
-      }
-    },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -9207,8 +8563,8 @@
         }
       }
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -9217,8 +8573,8 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -9227,38 +8583,8 @@
         }
       }
     },
-    "53": {
-      "id": "53",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 7
-        }
-      }
-    },
-    "54": {
-      "id": "54",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 8
-        }
-      }
-    },
-    "55": {
-      "id": "55",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 9
-        }
-      }
-    },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -9300,8 +8626,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -9315,67 +8641,76 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "11": {
+      "id": "11",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
+    "14": {
+      "id": "14",
+      "parentId": "13",
       "data": {}
     },
-    "48": {
-      "id": "48",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 2
-        }
-      }
-    },
-    "49": {
-      "id": "49",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 3
-        }
-      }
-    },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -9384,8 +8719,8 @@
         }
       }
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -9394,8 +8729,8 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -9404,38 +8739,8 @@
         }
       }
     },
-    "53": {
-      "id": "53",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 7
-        }
-      }
-    },
-    "54": {
-      "id": "54",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 8
-        }
-      }
-    },
-    "55": {
-      "id": "55",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 9
-        }
-      }
-    },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -9477,8 +8782,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -9492,67 +8797,76 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "11": {
+      "id": "11",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
+    "14": {
+      "id": "14",
+      "parentId": "13",
       "data": {}
     },
-    "48": {
-      "id": "48",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 2
-        }
-      }
-    },
-    "49": {
-      "id": "49",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 3
-        }
-      }
-    },
-    "50": {
-      "id": "50",
+    "19": {
+      "id": "19",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -9561,8 +8875,8 @@
         }
       }
     },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -9571,8 +8885,8 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -9581,38 +8895,8 @@
         }
       }
     },
-    "53": {
-      "id": "53",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 7
-        }
-      }
-    },
-    "54": {
-      "id": "54",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 8
-        }
-      }
-    },
-    "55": {
-      "id": "55",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 9
-        }
-      }
-    },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -9654,8 +8938,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -9669,77 +8953,76 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "11": {
+      "id": "11",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
+    "14": {
+      "id": "14",
+      "parentId": "13",
       "data": {}
     },
-    "48": {
-      "id": "48",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 2
-        }
-      }
-    },
-    "49": {
-      "id": "49",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 3
-        }
-      }
-    },
-    "50": {
-      "id": "50",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 4
-        }
-      }
-    },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -9748,8 +9031,8 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -9758,38 +9041,8 @@
         }
       }
     },
-    "53": {
-      "id": "53",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 7
-        }
-      }
-    },
-    "54": {
-      "id": "54",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 8
-        }
-      }
-    },
-    "55": {
-      "id": "55",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 9
-        }
-      }
-    },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -9831,8 +9084,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -9846,67 +9099,76 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "11": {
+      "id": "11",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
+    "14": {
+      "id": "14",
+      "parentId": "13",
       "data": {}
     },
-    "49": {
-      "id": "49",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 3
-        }
-      }
-    },
-    "50": {
-      "id": "50",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 4
-        }
-      }
-    },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -9915,8 +9177,8 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -9925,38 +9187,8 @@
         }
       }
     },
-    "53": {
-      "id": "53",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 7
-        }
-      }
-    },
-    "54": {
-      "id": "54",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 8
-        }
-      }
-    },
-    "55": {
-      "id": "55",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 9
-        }
-      }
-    },
-    "56": {
-      "id": "56",
+    "25": {
+      "id": "25",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -9998,8 +9230,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -10013,67 +9245,76 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "11": {
+      "id": "11",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
+    "14": {
+      "id": "14",
+      "parentId": "13",
       "data": {}
     },
-    "49": {
-      "id": "49",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 3
-        }
-      }
-    },
-    "50": {
-      "id": "50",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 4
-        }
-      }
-    },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -10082,8 +9323,8 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -10091,46 +9332,6 @@
           "number": 6
         }
       }
-    },
-    "53": {
-      "id": "53",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 7
-        }
-      }
-    },
-    "54": {
-      "id": "54",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 8
-        }
-      }
-    },
-    "55": {
-      "id": "55",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 9
-        }
-      }
-    },
-    "56": {
-      "id": "56",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 10
-        }
-      }
     }
   },
   {
@@ -10165,8 +9366,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -10180,67 +9381,76 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "11": {
+      "id": "11",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
+    "14": {
+      "id": "14",
+      "parentId": "13",
       "data": {}
     },
-    "49": {
-      "id": "49",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 3
-        }
-      }
-    },
-    "50": {
-      "id": "50",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 4
-        }
-      }
-    },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -10249,8 +9459,8 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -10258,36 +9468,6 @@
           "number": 6
         }
       }
-    },
-    "53": {
-      "id": "53",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 7
-        }
-      }
-    },
-    "55": {
-      "id": "55",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 9
-        }
-      }
-    },
-    "56": {
-      "id": "56",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 10
-        }
-      }
     }
   },
   {
@@ -10322,8 +9502,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -10337,67 +9517,76 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "11": {
+      "id": "11",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
+    "14": {
+      "id": "14",
+      "parentId": "13",
       "data": {}
     },
-    "49": {
-      "id": "49",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 3
-        }
-      }
-    },
-    "50": {
-      "id": "50",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 4
-        }
-      }
-    },
-    "51": {
-      "id": "51",
+    "20": {
+      "id": "20",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -10406,8 +9595,8 @@
         }
       }
     },
-    "52": {
-      "id": "52",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
@@ -10415,34 +9604,130 @@
           "number": 6
         }
       }
-    },
-    "53": {
-      "id": "53",
-      "parentId": "3",
+    }
+  },
+  {
+    "0": {
+      "id": "0",
       "data": {
         "@effection/attributes": {
-          "name": "child",
-          "number": 7
+          "name": "Global"
         }
       }
     },
-    "55": {
-      "id": "55",
-      "parentId": "3",
+    "1": {
+      "id": "1",
+      "parentId": "0",
       "data": {
         "@effection/attributes": {
-          "name": "child",
-          "number": 9
+          "name": "Inspector"
         }
       }
     },
-    "56": {
-      "id": "56",
+    "2": {
+      "id": "2",
+      "parentId": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "3": {
+      "id": "3",
+      "parentId": "2",
+      "data": {
+        "@effection/attributes": {
+          "name": "Main",
+          "args": "--suspend"
+        }
+      }
+    },
+    "4": {
+      "id": "4",
+      "parentId": "1",
+      "data": {
+        "@effection/attributes": {
+          "name": "SSEServer",
+          "port": 41000
+        }
+      }
+    },
+    "5": {
+      "id": "5",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/recordNodeMap"
+        }
+      }
+    },
+    "6": {
+      "id": "6",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "7": {
+      "id": "7",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "11": {
+      "id": "11",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
+      "data": {}
+    },
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    },
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
           "name": "child",
-          "number": 10
+          "number": 6
         }
       }
     }
@@ -10479,8 +9764,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -10494,102 +9779,81 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "11": {
+      "id": "11",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
+    "14": {
+      "id": "14",
+      "parentId": "13",
       "data": {}
     },
-    "49": {
-      "id": "49",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
           "name": "child",
-          "number": 3
-        }
-      }
-    },
-    "50": {
-      "id": "50",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 4
-        }
-      }
-    },
-    "51": {
-      "id": "51",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 5
-        }
-      }
-    },
-    "53": {
-      "id": "53",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 7
-        }
-      }
-    },
-    "55": {
-      "id": "55",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 9
-        }
-      }
-    },
-    "56": {
-      "id": "56",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 10
+          "number": 6
         }
       }
     }
@@ -10626,8 +9890,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -10641,102 +9905,81 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "11": {
+      "id": "11",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
+    "14": {
+      "id": "14",
+      "parentId": "13",
       "data": {}
     },
-    "49": {
-      "id": "49",
+    "21": {
+      "id": "21",
       "parentId": "3",
       "data": {
         "@effection/attributes": {
           "name": "child",
-          "number": 3
-        }
-      }
-    },
-    "50": {
-      "id": "50",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 4
-        }
-      }
-    },
-    "51": {
-      "id": "51",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 5
-        }
-      }
-    },
-    "53": {
-      "id": "53",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 7
-        }
-      }
-    },
-    "55": {
-      "id": "55",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 9
-        }
-      }
-    },
-    "56": {
-      "id": "56",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 10
+          "number": 6
         }
       }
     }
@@ -10773,8 +10016,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -10788,102 +10031,1675 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "11": {
+      "id": "11",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    }
+  },
+  {
+    "0": {
+      "id": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "Global"
+        }
+      }
+    },
+    "1": {
+      "id": "1",
+      "parentId": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "Inspector"
+        }
+      }
+    },
+    "2": {
+      "id": "2",
+      "parentId": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "3": {
+      "id": "3",
+      "parentId": "2",
+      "data": {
+        "@effection/attributes": {
+          "name": "Main",
+          "args": "--suspend"
+        }
+      }
+    },
+    "4": {
+      "id": "4",
+      "parentId": "1",
+      "data": {
+        "@effection/attributes": {
+          "name": "SSEServer",
+          "port": 41000
+        }
+      }
+    },
+    "5": {
+      "id": "5",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/recordNodeMap"
+        }
+      }
+    },
+    "6": {
+      "id": "6",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "7": {
+      "id": "7",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "11": {
+      "id": "11",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
       "data": {}
     },
-    "49": {
-      "id": "49",
-      "parentId": "3",
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    }
+  },
+  {
+    "0": {
+      "id": "0",
       "data": {
         "@effection/attributes": {
-          "name": "child",
-          "number": 3
+          "name": "Global"
         }
       }
     },
-    "50": {
-      "id": "50",
-      "parentId": "3",
+    "1": {
+      "id": "1",
+      "parentId": "0",
       "data": {
         "@effection/attributes": {
-          "name": "child",
-          "number": 4
+          "name": "Inspector"
         }
       }
     },
-    "51": {
-      "id": "51",
-      "parentId": "3",
+    "2": {
+      "id": "2",
+      "parentId": "0",
       "data": {
         "@effection/attributes": {
-          "name": "child",
-          "number": 5
+          "name": "anonymous"
         }
       }
     },
-    "53": {
-      "id": "53",
-      "parentId": "3",
+    "3": {
+      "id": "3",
+      "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "child",
-          "number": 7
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
-    "55": {
-      "id": "55",
-      "parentId": "3",
+    "4": {
+      "id": "4",
+      "parentId": "1",
       "data": {
         "@effection/attributes": {
-          "name": "child",
-          "number": 9
+          "name": "SSEServer",
+          "port": 41000
         }
       }
     },
-    "56": {
-      "id": "56",
-      "parentId": "3",
+    "5": {
+      "id": "5",
+      "parentId": "4",
       "data": {
         "@effection/attributes": {
-          "name": "child",
-          "number": 10
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/recordNodeMap"
+        }
+      }
+    },
+    "6": {
+      "id": "6",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "7": {
+      "id": "7",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "11": {
+      "id": "11",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
+      "data": {}
+    },
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    }
+  },
+  {
+    "0": {
+      "id": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "Global"
+        }
+      }
+    },
+    "1": {
+      "id": "1",
+      "parentId": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "Inspector"
+        }
+      }
+    },
+    "2": {
+      "id": "2",
+      "parentId": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "3": {
+      "id": "3",
+      "parentId": "2",
+      "data": {
+        "@effection/attributes": {
+          "name": "Main",
+          "args": "--suspend"
+        }
+      }
+    },
+    "4": {
+      "id": "4",
+      "parentId": "1",
+      "data": {
+        "@effection/attributes": {
+          "name": "SSEServer",
+          "port": 41000
+        }
+      }
+    },
+    "5": {
+      "id": "5",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/recordNodeMap"
+        }
+      }
+    },
+    "6": {
+      "id": "6",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "7": {
+      "id": "7",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "11": {
+      "id": "11",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
+      "data": {}
+    },
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    }
+  },
+  {
+    "0": {
+      "id": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "Global"
+        }
+      }
+    },
+    "1": {
+      "id": "1",
+      "parentId": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "Inspector"
+        }
+      }
+    },
+    "2": {
+      "id": "2",
+      "parentId": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "3": {
+      "id": "3",
+      "parentId": "2",
+      "data": {
+        "@effection/attributes": {
+          "name": "Main",
+          "args": "--suspend"
+        }
+      }
+    },
+    "4": {
+      "id": "4",
+      "parentId": "1",
+      "data": {
+        "@effection/attributes": {
+          "name": "SSEServer",
+          "port": 41000
+        }
+      }
+    },
+    "5": {
+      "id": "5",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/recordNodeMap"
+        }
+      }
+    },
+    "6": {
+      "id": "6",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "7": {
+      "id": "7",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "11": {
+      "id": "11",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
+      "data": {}
+    },
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    }
+  },
+  {
+    "0": {
+      "id": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "Global"
+        }
+      }
+    },
+    "1": {
+      "id": "1",
+      "parentId": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "Inspector"
+        }
+      }
+    },
+    "2": {
+      "id": "2",
+      "parentId": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "3": {
+      "id": "3",
+      "parentId": "2",
+      "data": {
+        "@effection/attributes": {
+          "name": "Main",
+          "args": "--suspend"
+        }
+      }
+    },
+    "4": {
+      "id": "4",
+      "parentId": "1",
+      "data": {
+        "@effection/attributes": {
+          "name": "SSEServer",
+          "port": 41000
+        }
+      }
+    },
+    "5": {
+      "id": "5",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/recordNodeMap"
+        }
+      }
+    },
+    "6": {
+      "id": "6",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "7": {
+      "id": "7",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "11": {
+      "id": "11",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
+      "data": {}
+    },
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    }
+  },
+  {
+    "0": {
+      "id": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "Global"
+        }
+      }
+    },
+    "1": {
+      "id": "1",
+      "parentId": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "Inspector"
+        }
+      }
+    },
+    "2": {
+      "id": "2",
+      "parentId": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "3": {
+      "id": "3",
+      "parentId": "2",
+      "data": {
+        "@effection/attributes": {
+          "name": "Main",
+          "args": "--suspend"
+        }
+      }
+    },
+    "4": {
+      "id": "4",
+      "parentId": "1",
+      "data": {
+        "@effection/attributes": {
+          "name": "SSEServer",
+          "port": 41000
+        }
+      }
+    },
+    "5": {
+      "id": "5",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/recordNodeMap"
+        }
+      }
+    },
+    "6": {
+      "id": "6",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "7": {
+      "id": "7",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "11": {
+      "id": "11",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
+      "data": {}
+    },
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    }
+  },
+  {
+    "0": {
+      "id": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "Global"
+        }
+      }
+    },
+    "1": {
+      "id": "1",
+      "parentId": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "Inspector"
+        }
+      }
+    },
+    "2": {
+      "id": "2",
+      "parentId": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "3": {
+      "id": "3",
+      "parentId": "2",
+      "data": {
+        "@effection/attributes": {
+          "name": "Main",
+          "args": "--suspend"
+        }
+      }
+    },
+    "4": {
+      "id": "4",
+      "parentId": "1",
+      "data": {
+        "@effection/attributes": {
+          "name": "SSEServer",
+          "port": 41000
+        }
+      }
+    },
+    "5": {
+      "id": "5",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/recordNodeMap"
+        }
+      }
+    },
+    "6": {
+      "id": "6",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "7": {
+      "id": "7",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "11": {
+      "id": "11",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
+      "data": {}
+    },
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    }
+  },
+  {
+    "0": {
+      "id": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "Global"
+        }
+      }
+    },
+    "1": {
+      "id": "1",
+      "parentId": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "Inspector"
+        }
+      }
+    },
+    "2": {
+      "id": "2",
+      "parentId": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "3": {
+      "id": "3",
+      "parentId": "2",
+      "data": {
+        "@effection/attributes": {
+          "name": "Main",
+          "args": "--suspend"
+        }
+      }
+    },
+    "4": {
+      "id": "4",
+      "parentId": "1",
+      "data": {
+        "@effection/attributes": {
+          "name": "SSEServer",
+          "port": 41000
+        }
+      }
+    },
+    "5": {
+      "id": "5",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/recordNodeMap"
+        }
+      }
+    },
+    "6": {
+      "id": "6",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "7": {
+      "id": "7",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "11": {
+      "id": "11",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
+      "data": {}
+    },
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    }
+  },
+  {
+    "0": {
+      "id": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "Global"
+        }
+      }
+    },
+    "1": {
+      "id": "1",
+      "parentId": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "Inspector"
+        }
+      }
+    },
+    "2": {
+      "id": "2",
+      "parentId": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "3": {
+      "id": "3",
+      "parentId": "2",
+      "data": {
+        "@effection/attributes": {
+          "name": "Main",
+          "args": "--suspend"
+        }
+      }
+    },
+    "4": {
+      "id": "4",
+      "parentId": "1",
+      "data": {
+        "@effection/attributes": {
+          "name": "SSEServer",
+          "port": 41000
+        }
+      }
+    },
+    "5": {
+      "id": "5",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/recordNodeMap"
+        }
+      }
+    },
+    "6": {
+      "id": "6",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "7": {
+      "id": "7",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "11": {
+      "id": "11",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
+      "data": {}
+    },
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    }
+  },
+  {
+    "0": {
+      "id": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "Global"
+        }
+      }
+    },
+    "1": {
+      "id": "1",
+      "parentId": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "Inspector"
+        }
+      }
+    },
+    "2": {
+      "id": "2",
+      "parentId": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "3": {
+      "id": "3",
+      "parentId": "2",
+      "data": {
+        "@effection/attributes": {
+          "name": "Main",
+          "args": "--suspend"
+        }
+      }
+    },
+    "4": {
+      "id": "4",
+      "parentId": "1",
+      "data": {
+        "@effection/attributes": {
+          "name": "SSEServer",
+          "port": 41000
+        }
+      }
+    },
+    "5": {
+      "id": "5",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/recordNodeMap"
+        }
+      }
+    },
+    "6": {
+      "id": "6",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "7": {
+      "id": "7",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "11": {
+      "id": "11",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
+      "data": {}
+    },
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    }
+  },
+  {
+    "0": {
+      "id": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "Global"
+        }
+      }
+    },
+    "1": {
+      "id": "1",
+      "parentId": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "Inspector"
+        }
+      }
+    },
+    "2": {
+      "id": "2",
+      "parentId": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "3": {
+      "id": "3",
+      "parentId": "2",
+      "data": {
+        "@effection/attributes": {
+          "name": "Main",
+          "args": "--suspend"
+        }
+      }
+    },
+    "4": {
+      "id": "4",
+      "parentId": "1",
+      "data": {
+        "@effection/attributes": {
+          "name": "SSEServer",
+          "port": 41000
+        }
+      }
+    },
+    "5": {
+      "id": "5",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/recordNodeMap"
+        }
+      }
+    },
+    "6": {
+      "id": "6",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "7": {
+      "id": "7",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "11": {
+      "id": "11",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
+      "data": {}
+    },
+    "14": {
+      "id": "14",
+      "parentId": "13",
+      "data": {}
+    }
+  },
+  {
+    "0": {
+      "id": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "Global"
+        }
+      }
+    },
+    "1": {
+      "id": "1",
+      "parentId": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "Inspector"
+        }
+      }
+    },
+    "2": {
+      "id": "2",
+      "parentId": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "3": {
+      "id": "3",
+      "parentId": "2",
+      "data": {
+        "@effection/attributes": {
+          "name": "Main",
+          "args": "--suspend"
+        }
+      }
+    },
+    "4": {
+      "id": "4",
+      "parentId": "1",
+      "data": {
+        "@effection/attributes": {
+          "name": "SSEServer",
+          "port": 41000
+        }
+      }
+    },
+    "5": {
+      "id": "5",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/recordNodeMap"
+        }
+      }
+    },
+    "6": {
+      "id": "6",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "7": {
+      "id": "7",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "11": {
+      "id": "11",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
+      "data": {}
+    }
+  },
+  {
+    "0": {
+      "id": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "Global"
+        }
+      }
+    },
+    "1": {
+      "id": "1",
+      "parentId": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "Inspector"
+        }
+      }
+    },
+    "2": {
+      "id": "2",
+      "parentId": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "3": {
+      "id": "3",
+      "parentId": "2",
+      "data": {
+        "@effection/attributes": {
+          "name": "Main",
+          "args": "--suspend"
+        }
+      }
+    },
+    "4": {
+      "id": "4",
+      "parentId": "1",
+      "data": {
+        "@effection/attributes": {
+          "name": "SSEServer",
+          "port": 41000
+        }
+      }
+    },
+    "5": {
+      "id": "5",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/recordNodeMap"
+        }
+      }
+    },
+    "6": {
+      "id": "6",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "7": {
+      "id": "7",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "11": {
+      "id": "11",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "13": {
+      "id": "13",
+      "parentId": "11",
+      "data": {}
+    }
+  },
+  {
+    "0": {
+      "id": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "Global"
+        }
+      }
+    },
+    "1": {
+      "id": "1",
+      "parentId": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "Inspector"
+        }
+      }
+    },
+    "2": {
+      "id": "2",
+      "parentId": "0",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "3": {
+      "id": "3",
+      "parentId": "2",
+      "data": {
+        "@effection/attributes": {
+          "name": "Main",
+          "args": "--suspend"
+        }
+      }
+    },
+    "4": {
+      "id": "4",
+      "parentId": "1",
+      "data": {
+        "@effection/attributes": {
+          "name": "SSEServer",
+          "port": 41000
+        }
+      }
+    },
+    "5": {
+      "id": "5",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/recordNodeMap"
+        }
+      }
+    },
+    "6": {
+      "id": "6",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "7": {
+      "id": "7",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "11": {
+      "id": "11",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     }
@@ -10920,8 +11736,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -10935,92 +11751,61 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
-    },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
-    },
-    "50": {
-      "id": "50",
-      "parentId": "3",
+    "8": {
+      "id": "8",
+      "parentId": "7",
       "data": {
         "@effection/attributes": {
-          "name": "child",
-          "number": 4
+          "name": "anonymous"
         }
       }
     },
-    "51": {
-      "id": "51",
-      "parentId": "3",
+    "9": {
+      "id": "9",
+      "parentId": "6",
       "data": {
         "@effection/attributes": {
-          "name": "child",
-          "number": 5
+          "name": "EventStream"
         }
       }
     },
-    "53": {
-      "id": "53",
-      "parentId": "3",
+    "11": {
+      "id": "11",
+      "parentId": "4",
       "data": {
         "@effection/attributes": {
-          "name": "child",
-          "number": 7
-        }
-      }
-    },
-    "55": {
-      "id": "55",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 9
-        }
-      }
-    },
-    "56": {
-      "id": "56",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 10
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     }
@@ -11057,8 +11842,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -11072,92 +11857,50 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
-    },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
-    },
-    "50": {
-      "id": "50",
-      "parentId": "3",
+    "8": {
+      "id": "8",
+      "parentId": "7",
       "data": {
         "@effection/attributes": {
-          "name": "child",
-          "number": 4
+          "name": "anonymous"
         }
       }
     },
-    "51": {
-      "id": "51",
-      "parentId": "3",
+    "9": {
+      "id": "9",
+      "parentId": "6",
       "data": {
         "@effection/attributes": {
-          "name": "child",
-          "number": 5
-        }
-      }
-    },
-    "53": {
-      "id": "53",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 7
-        }
-      }
-    },
-    "55": {
-      "id": "55",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 9
-        }
-      }
-    },
-    "56": {
-      "id": "56",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 10
+          "name": "EventStream"
         }
       }
     }
@@ -11194,8 +11937,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -11209,92 +11952,161 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "26": {
+      "id": "26",
+      "parentId": "4",
       "data": {}
-    },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
-    },
-    "50": {
-      "id": "50",
-      "parentId": "3",
+    }
+  },
+  {
+    "0": {
+      "id": "0",
       "data": {
         "@effection/attributes": {
-          "name": "child",
-          "number": 4
+          "name": "Global"
         }
       }
     },
-    "51": {
-      "id": "51",
-      "parentId": "3",
+    "1": {
+      "id": "1",
+      "parentId": "0",
       "data": {
         "@effection/attributes": {
-          "name": "child",
-          "number": 5
+          "name": "Inspector"
         }
       }
     },
-    "53": {
-      "id": "53",
-      "parentId": "3",
+    "2": {
+      "id": "2",
+      "parentId": "0",
       "data": {
         "@effection/attributes": {
-          "name": "child",
-          "number": 7
+          "name": "anonymous"
         }
       }
     },
-    "55": {
-      "id": "55",
-      "parentId": "3",
+    "3": {
+      "id": "3",
+      "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "child",
-          "number": 9
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
-    "56": {
-      "id": "56",
-      "parentId": "3",
+    "4": {
+      "id": "4",
+      "parentId": "1",
       "data": {
         "@effection/attributes": {
-          "name": "child",
-          "number": 10
+          "name": "SSEServer",
+          "port": 41000
+        }
+      }
+    },
+    "5": {
+      "id": "5",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/recordNodeMap"
+        }
+      }
+    },
+    "6": {
+      "id": "6",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "7": {
+      "id": "7",
+      "parentId": "5",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "26": {
+      "id": "26",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     }
@@ -11331,8 +12143,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -11346,1919 +12158,67 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "39": {
-      "id": "39",
-      "parentId": "32",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
-    },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
-    },
-    "51": {
-      "id": "51",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 5
-        }
-      }
-    },
-    "53": {
-      "id": "53",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 7
-        }
-      }
-    },
-    "55": {
-      "id": "55",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 9
-        }
-      }
-    },
-    "56": {
-      "id": "56",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 10
-        }
-      }
-    }
-  },
-  {
-    "0": {
-      "id": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Global"
-        }
-      }
-    },
-    "1": {
-      "id": "1",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Inspector"
-        }
-      }
-    },
-    "2": {
-      "id": "2",
-      "parentId": "0",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
           "name": "anonymous"
         }
       }
     },
-    "3": {
-      "id": "3",
-      "parentId": "2",
-      "data": {
-        "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
-        }
-      }
-    },
-    "4": {
-      "id": "4",
-      "parentId": "1",
-      "data": {
-        "@effection/attributes": {
-          "name": "SSEServer",
-          "port": 41000
-        }
-      }
-    },
-    "31": {
-      "id": "31",
-      "parentId": "4",
-      "data": {
-        "@effection/attributes": {
-          "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
-        }
-      }
-    },
-    "32": {
-      "id": "32",
-      "parentId": "31",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "39": {
-      "id": "39",
-      "parentId": "32",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
-    },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
-    },
-    "51": {
-      "id": "51",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 5
-        }
-      }
-    },
-    "53": {
-      "id": "53",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 7
-        }
-      }
-    },
-    "55": {
-      "id": "55",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 9
-        }
-      }
-    },
-    "56": {
-      "id": "56",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 10
-        }
-      }
-    }
-  },
-  {
-    "0": {
-      "id": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Global"
-        }
-      }
-    },
-    "1": {
-      "id": "1",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Inspector"
-        }
-      }
-    },
-    "2": {
-      "id": "2",
-      "parentId": "0",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
           "name": "anonymous"
         }
       }
     },
-    "3": {
-      "id": "3",
-      "parentId": "2",
-      "data": {
-        "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
-        }
-      }
-    },
-    "4": {
-      "id": "4",
-      "parentId": "1",
-      "data": {
-        "@effection/attributes": {
-          "name": "SSEServer",
-          "port": 41000
-        }
-      }
-    },
-    "31": {
-      "id": "31",
-      "parentId": "4",
-      "data": {
-        "@effection/attributes": {
-          "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
-        }
-      }
-    },
-    "32": {
-      "id": "32",
-      "parentId": "31",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "39": {
-      "id": "39",
-      "parentId": "32",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
-    },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
-    },
-    "51": {
-      "id": "51",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 5
-        }
-      }
-    },
-    "55": {
-      "id": "55",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 9
-        }
-      }
-    },
-    "56": {
-      "id": "56",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 10
-        }
-      }
-    }
-  },
-  {
-    "0": {
-      "id": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Global"
-        }
-      }
-    },
-    "1": {
-      "id": "1",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Inspector"
-        }
-      }
-    },
-    "2": {
-      "id": "2",
-      "parentId": "0",
+    "8": {
+      "id": "8",
+      "parentId": "7",
       "data": {
         "@effection/attributes": {
           "name": "anonymous"
         }
       }
     },
-    "3": {
-      "id": "3",
-      "parentId": "2",
+    "9": {
+      "id": "9",
+      "parentId": "6",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "EventStream"
         }
       }
     },
-    "4": {
-      "id": "4",
-      "parentId": "1",
-      "data": {
-        "@effection/attributes": {
-          "name": "SSEServer",
-          "port": 41000
-        }
-      }
-    },
-    "31": {
-      "id": "31",
+    "26": {
+      "id": "26",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/play"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "39": {
-      "id": "39",
-      "parentId": "32",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
-    },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
-    },
-    "51": {
-      "id": "51",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 5
-        }
-      }
-    },
-    "55": {
-      "id": "55",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 9
-        }
-      }
-    },
-    "56": {
-      "id": "56",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 10
-        }
-      }
-    }
-  },
-  {
-    "0": {
-      "id": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Global"
-        }
-      }
-    },
-    "1": {
-      "id": "1",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Inspector"
-        }
-      }
-    },
-    "2": {
-      "id": "2",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "anonymous"
-        }
-      }
-    },
-    "3": {
-      "id": "3",
-      "parentId": "2",
-      "data": {
-        "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
-        }
-      }
-    },
-    "4": {
-      "id": "4",
-      "parentId": "1",
-      "data": {
-        "@effection/attributes": {
-          "name": "SSEServer",
-          "port": 41000
-        }
-      }
-    },
-    "31": {
-      "id": "31",
-      "parentId": "4",
-      "data": {
-        "@effection/attributes": {
-          "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
-        }
-      }
-    },
-    "32": {
-      "id": "32",
-      "parentId": "31",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "39": {
-      "id": "39",
-      "parentId": "32",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
-    },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
-    },
-    "51": {
-      "id": "51",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 5
-        }
-      }
-    },
-    "56": {
-      "id": "56",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 10
-        }
-      }
-    }
-  },
-  {
-    "0": {
-      "id": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Global"
-        }
-      }
-    },
-    "1": {
-      "id": "1",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Inspector"
-        }
-      }
-    },
-    "2": {
-      "id": "2",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "anonymous"
-        }
-      }
-    },
-    "3": {
-      "id": "3",
-      "parentId": "2",
-      "data": {
-        "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
-        }
-      }
-    },
-    "4": {
-      "id": "4",
-      "parentId": "1",
-      "data": {
-        "@effection/attributes": {
-          "name": "SSEServer",
-          "port": 41000
-        }
-      }
-    },
-    "31": {
-      "id": "31",
-      "parentId": "4",
-      "data": {
-        "@effection/attributes": {
-          "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
-        }
-      }
-    },
-    "32": {
-      "id": "32",
-      "parentId": "31",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "39": {
-      "id": "39",
-      "parentId": "32",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
-    },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
-    },
-    "51": {
-      "id": "51",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 5
-        }
-      }
-    },
-    "56": {
-      "id": "56",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 10
-        }
-      }
-    }
-  },
-  {
-    "0": {
-      "id": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Global"
-        }
-      }
-    },
-    "1": {
-      "id": "1",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Inspector"
-        }
-      }
-    },
-    "2": {
-      "id": "2",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "anonymous"
-        }
-      }
-    },
-    "3": {
-      "id": "3",
-      "parentId": "2",
-      "data": {
-        "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
-        }
-      }
-    },
-    "4": {
-      "id": "4",
-      "parentId": "1",
-      "data": {
-        "@effection/attributes": {
-          "name": "SSEServer",
-          "port": 41000
-        }
-      }
-    },
-    "31": {
-      "id": "31",
-      "parentId": "4",
-      "data": {
-        "@effection/attributes": {
-          "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
-        }
-      }
-    },
-    "32": {
-      "id": "32",
-      "parentId": "31",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "39": {
-      "id": "39",
-      "parentId": "32",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
-    },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
-    },
-    "51": {
-      "id": "51",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 5
-        }
-      }
-    },
-    "56": {
-      "id": "56",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 10
-        }
-      }
-    }
-  },
-  {
-    "0": {
-      "id": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Global"
-        }
-      }
-    },
-    "1": {
-      "id": "1",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Inspector"
-        }
-      }
-    },
-    "2": {
-      "id": "2",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "anonymous"
-        }
-      }
-    },
-    "3": {
-      "id": "3",
-      "parentId": "2",
-      "data": {
-        "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
-        }
-      }
-    },
-    "4": {
-      "id": "4",
-      "parentId": "1",
-      "data": {
-        "@effection/attributes": {
-          "name": "SSEServer",
-          "port": 41000
-        }
-      }
-    },
-    "31": {
-      "id": "31",
-      "parentId": "4",
-      "data": {
-        "@effection/attributes": {
-          "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
-        }
-      }
-    },
-    "32": {
-      "id": "32",
-      "parentId": "31",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "39": {
-      "id": "39",
-      "parentId": "32",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
-    },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
-    },
-    "56": {
-      "id": "56",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 10
-        }
-      }
-    }
-  },
-  {
-    "0": {
-      "id": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Global"
-        }
-      }
-    },
-    "1": {
-      "id": "1",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Inspector"
-        }
-      }
-    },
-    "2": {
-      "id": "2",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "anonymous"
-        }
-      }
-    },
-    "3": {
-      "id": "3",
-      "parentId": "2",
-      "data": {
-        "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
-        }
-      }
-    },
-    "4": {
-      "id": "4",
-      "parentId": "1",
-      "data": {
-        "@effection/attributes": {
-          "name": "SSEServer",
-          "port": 41000
-        }
-      }
-    },
-    "31": {
-      "id": "31",
-      "parentId": "4",
-      "data": {
-        "@effection/attributes": {
-          "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
-        }
-      }
-    },
-    "32": {
-      "id": "32",
-      "parentId": "31",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "39": {
-      "id": "39",
-      "parentId": "32",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
-    },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
-    },
-    "56": {
-      "id": "56",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 10
-        }
-      }
-    }
-  },
-  {
-    "0": {
-      "id": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Global"
-        }
-      }
-    },
-    "1": {
-      "id": "1",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Inspector"
-        }
-      }
-    },
-    "2": {
-      "id": "2",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "anonymous"
-        }
-      }
-    },
-    "3": {
-      "id": "3",
-      "parentId": "2",
-      "data": {
-        "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
-        }
-      }
-    },
-    "4": {
-      "id": "4",
-      "parentId": "1",
-      "data": {
-        "@effection/attributes": {
-          "name": "SSEServer",
-          "port": 41000
-        }
-      }
-    },
-    "31": {
-      "id": "31",
-      "parentId": "4",
-      "data": {
-        "@effection/attributes": {
-          "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
-        }
-      }
-    },
-    "32": {
-      "id": "32",
-      "parentId": "31",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "39": {
-      "id": "39",
-      "parentId": "32",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
-    },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
-    },
-    "56": {
-      "id": "56",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 10
-        }
-      }
-    }
-  },
-  {
-    "0": {
-      "id": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Global"
-        }
-      }
-    },
-    "1": {
-      "id": "1",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Inspector"
-        }
-      }
-    },
-    "2": {
-      "id": "2",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "anonymous"
-        }
-      }
-    },
-    "3": {
-      "id": "3",
-      "parentId": "2",
-      "data": {
-        "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
-        }
-      }
-    },
-    "4": {
-      "id": "4",
-      "parentId": "1",
-      "data": {
-        "@effection/attributes": {
-          "name": "SSEServer",
-          "port": 41000
-        }
-      }
-    },
-    "31": {
-      "id": "31",
-      "parentId": "4",
-      "data": {
-        "@effection/attributes": {
-          "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
-        }
-      }
-    },
-    "32": {
-      "id": "32",
-      "parentId": "31",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "39": {
-      "id": "39",
-      "parentId": "32",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
-    },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
-    },
-    "56": {
-      "id": "56",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 10
-        }
-      }
-    }
-  },
-  {
-    "0": {
-      "id": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Global"
-        }
-      }
-    },
-    "1": {
-      "id": "1",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Inspector"
-        }
-      }
-    },
-    "2": {
-      "id": "2",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "anonymous"
-        }
-      }
-    },
-    "3": {
-      "id": "3",
-      "parentId": "2",
-      "data": {
-        "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
-        }
-      }
-    },
-    "4": {
-      "id": "4",
-      "parentId": "1",
-      "data": {
-        "@effection/attributes": {
-          "name": "SSEServer",
-          "port": 41000
-        }
-      }
-    },
-    "31": {
-      "id": "31",
-      "parentId": "4",
-      "data": {
-        "@effection/attributes": {
-          "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
-        }
-      }
-    },
-    "32": {
-      "id": "32",
-      "parentId": "31",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "39": {
-      "id": "39",
-      "parentId": "32",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
-    },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
-    },
-    "56": {
-      "id": "56",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 10
-        }
-      }
-    }
-  },
-  {
-    "0": {
-      "id": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Global"
-        }
-      }
-    },
-    "1": {
-      "id": "1",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Inspector"
-        }
-      }
-    },
-    "2": {
-      "id": "2",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "anonymous"
-        }
-      }
-    },
-    "3": {
-      "id": "3",
-      "parentId": "2",
-      "data": {
-        "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
-        }
-      }
-    },
-    "4": {
-      "id": "4",
-      "parentId": "1",
-      "data": {
-        "@effection/attributes": {
-          "name": "SSEServer",
-          "port": 41000
-        }
-      }
-    },
-    "31": {
-      "id": "31",
-      "parentId": "4",
-      "data": {
-        "@effection/attributes": {
-          "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
-        }
-      }
-    },
-    "32": {
-      "id": "32",
-      "parentId": "31",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "39": {
-      "id": "39",
-      "parentId": "32",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
-    },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
-    },
-    "56": {
-      "id": "56",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 10
-        }
-      }
-    }
-  },
-  {
-    "0": {
-      "id": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Global"
-        }
-      }
-    },
-    "1": {
-      "id": "1",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Inspector"
-        }
-      }
-    },
-    "2": {
-      "id": "2",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "anonymous"
-        }
-      }
-    },
-    "3": {
-      "id": "3",
-      "parentId": "2",
-      "data": {
-        "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
-        }
-      }
-    },
-    "4": {
-      "id": "4",
-      "parentId": "1",
-      "data": {
-        "@effection/attributes": {
-          "name": "SSEServer",
-          "port": 41000
-        }
-      }
-    },
-    "31": {
-      "id": "31",
-      "parentId": "4",
-      "data": {
-        "@effection/attributes": {
-          "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
-        }
-      }
-    },
-    "32": {
-      "id": "32",
-      "parentId": "31",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "39": {
-      "id": "39",
-      "parentId": "32",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
-    },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
-    },
-    "56": {
-      "id": "56",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 10
-        }
-      }
-    }
-  },
-  {
-    "0": {
-      "id": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Global"
-        }
-      }
-    },
-    "1": {
-      "id": "1",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Inspector"
-        }
-      }
-    },
-    "2": {
-      "id": "2",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "anonymous"
-        }
-      }
-    },
-    "3": {
-      "id": "3",
-      "parentId": "2",
-      "data": {
-        "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
-        }
-      }
-    },
-    "4": {
-      "id": "4",
-      "parentId": "1",
-      "data": {
-        "@effection/attributes": {
-          "name": "SSEServer",
-          "port": 41000
-        }
-      }
-    },
-    "31": {
-      "id": "31",
-      "parentId": "4",
-      "data": {
-        "@effection/attributes": {
-          "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
-        }
-      }
-    },
-    "32": {
-      "id": "32",
-      "parentId": "31",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "39": {
-      "id": "39",
-      "parentId": "32",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
-    },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
-    },
-    "56": {
-      "id": "56",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 10
-        }
-      }
-    }
-  },
-  {
-    "0": {
-      "id": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Global"
-        }
-      }
-    },
-    "1": {
-      "id": "1",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Inspector"
-        }
-      }
-    },
-    "2": {
-      "id": "2",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "anonymous"
-        }
-      }
-    },
-    "3": {
-      "id": "3",
-      "parentId": "2",
-      "data": {
-        "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
-        }
-      }
-    },
-    "4": {
-      "id": "4",
-      "parentId": "1",
-      "data": {
-        "@effection/attributes": {
-          "name": "SSEServer",
-          "port": 41000
-        }
-      }
-    },
-    "31": {
-      "id": "31",
-      "parentId": "4",
-      "data": {
-        "@effection/attributes": {
-          "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
-        }
-      }
-    },
-    "32": {
-      "id": "32",
-      "parentId": "31",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "39": {
-      "id": "39",
-      "parentId": "32",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
-    },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
-    },
-    "56": {
-      "id": "56",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 10
-        }
-      }
-    }
-  },
-  {
-    "0": {
-      "id": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Global"
-        }
-      }
-    },
-    "1": {
-      "id": "1",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Inspector"
-        }
-      }
-    },
-    "2": {
-      "id": "2",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "anonymous"
-        }
-      }
-    },
-    "3": {
-      "id": "3",
-      "parentId": "2",
-      "data": {
-        "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
-        }
-      }
-    },
-    "4": {
-      "id": "4",
-      "parentId": "1",
-      "data": {
-        "@effection/attributes": {
-          "name": "SSEServer",
-          "port": 41000
-        }
-      }
-    },
-    "31": {
-      "id": "31",
-      "parentId": "4",
-      "data": {
-        "@effection/attributes": {
-          "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
-        }
-      }
-    },
-    "32": {
-      "id": "32",
-      "parentId": "31",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "39": {
-      "id": "39",
-      "parentId": "32",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
-    },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
-    },
-    "56": {
-      "id": "56",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 10
-        }
-      }
-    }
-  },
-  {
-    "0": {
-      "id": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Global"
-        }
-      }
-    },
-    "1": {
-      "id": "1",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Inspector"
-        }
-      }
-    },
-    "2": {
-      "id": "2",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "anonymous"
-        }
-      }
-    },
-    "3": {
-      "id": "3",
-      "parentId": "2",
-      "data": {
-        "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
-        }
-      }
-    },
-    "4": {
-      "id": "4",
-      "parentId": "1",
-      "data": {
-        "@effection/attributes": {
-          "name": "SSEServer",
-          "port": 41000
-        }
-      }
-    },
-    "31": {
-      "id": "31",
-      "parentId": "4",
-      "data": {
-        "@effection/attributes": {
-          "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
-        }
-      }
-    },
-    "32": {
-      "id": "32",
-      "parentId": "31",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "39": {
-      "id": "39",
-      "parentId": "32",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
-    },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
-    },
-    "56": {
-      "id": "56",
-      "parentId": "3",
-      "data": {
-        "@effection/attributes": {
-          "name": "child",
-          "number": 10
-        }
-      }
-    }
-  },
-  {
-    "0": {
-      "id": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Global"
-        }
-      }
-    },
-    "1": {
-      "id": "1",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Inspector"
-        }
-      }
-    },
-    "2": {
-      "id": "2",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "anonymous"
-        }
-      }
-    },
-    "3": {
-      "id": "3",
-      "parentId": "2",
-      "data": {
-        "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
-        }
-      }
-    },
-    "4": {
-      "id": "4",
-      "parentId": "1",
-      "data": {
-        "@effection/attributes": {
-          "name": "SSEServer",
-          "port": 41000
-        }
-      }
-    },
-    "31": {
-      "id": "31",
-      "parentId": "4",
-      "data": {
-        "@effection/attributes": {
-          "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
-        }
-      }
-    },
-    "32": {
-      "id": "32",
-      "parentId": "31",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "39": {
-      "id": "39",
-      "parentId": "32",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
-    },
-    "41": {
-      "id": "41",
-      "parentId": "32",
+    "27": {
+      "id": "27",
+      "parentId": "26",
       "data": {}
     }
   },
@@ -13294,8 +12254,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -13309,43 +12269,72 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "26": {
+      "id": "26",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "27": {
+      "id": "27",
+      "parentId": "26",
       "data": {}
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
+    "28": {
+      "id": "28",
+      "parentId": "26",
       "data": {}
     }
   },
@@ -13381,8 +12370,8 @@
       "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "main",
-          "args": ["--break"]
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -13396,43 +12385,77 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "26": {
+      "id": "26",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "27": {
+      "id": "27",
+      "parentId": "26",
       "data": {}
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
+    "28": {
+      "id": "28",
+      "parentId": "26",
+      "data": {}
+    },
+    "29": {
+      "id": "29",
+      "parentId": "28",
       "data": {}
     }
   },
@@ -13463,6 +12486,16 @@
         }
       }
     },
+    "3": {
+      "id": "3",
+      "parentId": "2",
+      "data": {
+        "@effection/attributes": {
+          "name": "Main",
+          "args": "--suspend"
+        }
+      }
+    },
     "4": {
       "id": "4",
       "parentId": "1",
@@ -13473,43 +12506,82 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "26": {
+      "id": "26",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "27": {
+      "id": "27",
+      "parentId": "26",
       "data": {}
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
+    "28": {
+      "id": "28",
+      "parentId": "26",
+      "data": {}
+    },
+    "29": {
+      "id": "29",
+      "parentId": "28",
+      "data": {}
+    },
+    "30": {
+      "id": "30",
+      "parentId": "27",
       "data": {}
     }
   },
@@ -13540,71 +12612,13 @@
         }
       }
     },
-    "4": {
-      "id": "4",
-      "parentId": "1",
+    "3": {
+      "id": "3",
+      "parentId": "2",
       "data": {
         "@effection/attributes": {
-          "name": "SSEServer",
-          "port": 41000
-        }
-      }
-    },
-    "31": {
-      "id": "31",
-      "parentId": "4",
-      "data": {
-        "@effection/attributes": {
-          "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
-        }
-      }
-    },
-    "32": {
-      "id": "32",
-      "parentId": "31",
-      "data": {
-        "@effection/attributes": {
-          "name": "Transport"
-        }
-      }
-    },
-    "39": {
-      "id": "39",
-      "parentId": "32",
-      "data": {
-        "@effection/attributes": {
-          "name": "streamEvents"
-        }
-      }
-    },
-    "40": {
-      "id": "40",
-      "parentId": "32",
-      "data": {}
-    },
-    "41": {
-      "id": "41",
-      "parentId": "32",
-      "data": {}
-    }
-  },
-  {
-    "0": {
-      "id": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Global"
-        }
-      }
-    },
-    "1": {
-      "id": "1",
-      "parentId": "0",
-      "data": {
-        "@effection/attributes": {
-          "name": "Inspector"
+          "name": "Main",
+          "args": "--suspend"
         }
       }
     },
@@ -13618,44 +12632,87 @@
         }
       }
     },
-    "31": {
-      "id": "31",
+    "5": {
+      "id": "5",
       "parentId": "4",
       "data": {
         "@effection/attributes": {
           "name": "RequestHandler",
-          "url": "/watchScopes",
-          "method": "POST"
+          "method": "POST",
+          "pathname": "/recordNodeMap"
         }
       }
     },
-    "32": {
-      "id": "32",
-      "parentId": "31",
+    "6": {
+      "id": "6",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "Transport"
+          "name": "anonymous"
         }
       }
     },
-    "39": {
-      "id": "39",
-      "parentId": "32",
+    "7": {
+      "id": "7",
+      "parentId": "5",
       "data": {
         "@effection/attributes": {
-          "name": "streamEvents"
+          "name": "anonymous"
         }
       }
     },
-    "40": {
-      "id": "40",
-      "parentId": "32",
+    "8": {
+      "id": "8",
+      "parentId": "7",
+      "data": {
+        "@effection/attributes": {
+          "name": "anonymous"
+        }
+      }
+    },
+    "9": {
+      "id": "9",
+      "parentId": "6",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
+    },
+    "26": {
+      "id": "26",
+      "parentId": "4",
+      "data": {
+        "@effection/attributes": {
+          "name": "RequestHandler",
+          "method": "POST",
+          "pathname": "/play"
+        }
+      }
+    },
+    "27": {
+      "id": "27",
+      "parentId": "26",
       "data": {}
     },
-    "41": {
-      "id": "41",
-      "parentId": "32",
+    "28": {
+      "id": "28",
+      "parentId": "26",
       "data": {}
+    },
+    "29": {
+      "id": "29",
+      "parentId": "28",
+      "data": {}
+    },
+    "30": {
+      "id": "30",
+      "parentId": "27",
+      "data": {
+        "@effection/attributes": {
+          "name": "EventStream"
+        }
+      }
     }
   }
 ]

--- a/crank/app/demo.tsx
+++ b/crank/app/demo.tsx
@@ -1,6 +1,6 @@
 import type { Context, Element } from "@b9g/crank";
 import { Layout } from "./layout.tsx";
-import type { NodeMap } from "./data/types.ts";
+import type { NodeMap } from "../../lib/update-node-map.ts";
 import { RenderRecording } from "./components/render-recording.tsx";
 import json from "./demo.json" with { type: "json" };
 

--- a/crank/app/live.tsx
+++ b/crank/app/live.tsx
@@ -1,7 +1,7 @@
 import type { Context } from "@b9g/crank";
 import { pipe } from "remeda";
 
-import { updateNodeMap } from "./data/update-node-map.ts";
+import { updateNodeMap } from "../../lib/update-node-map.ts";
 import { stratify } from "./data/stratify.ts";
 import { createSSEClient } from "../../lib/sse-client.ts";
 import { protocol as scope } from "../../scope/protocol.ts";

--- a/crank/app/recording.tsx
+++ b/crank/app/recording.tsx
@@ -9,7 +9,7 @@ import {
   until,
   type Operation,
 } from "effection";
-import type { NodeMap } from "./data/types.ts";
+import type { NodeMap } from "../../lib/update-node-map.ts";
 import { RenderRecording } from "./components/render-recording.tsx";
 
 export async function* Recording(this: Context): AsyncGenerator<Element> {

--- a/crank/app/recording.tsx
+++ b/crank/app/recording.tsx
@@ -2,13 +2,7 @@ import type { Context } from "@b9g/crank";
 import { Layout } from "./layout.tsx";
 import { router } from "../src/router.ts";
 
-import {
-  createScope,
-  each,
-  createSignal,
-  until,
-  type Operation,
-} from "effection";
+import { createScope, each, createSignal, until, type Operation } from "effection";
 import type { NodeMap } from "../../lib/update-node-map.ts";
 import { RenderRecording } from "./components/render-recording.tsx";
 

--- a/lib/update-node-map.ts
+++ b/lib/update-node-map.ts
@@ -1,3 +1,4 @@
+import { Json } from "@ark/util";
 import type { ScopeEvent } from "../scope/protocol.ts";
 import { reduce } from "./reduce.ts";
 import type { Stream } from "effection";
@@ -5,15 +6,12 @@ import type { Stream } from "effection";
 /**
  * A function that transforms one stream into another
  */
-
-export type Transform<A, B> = <TClose>(
-  input: Stream<A, TClose>,
-) => Stream<B, TClose>;
+export type Transform<A, B> = <TClose>(input: Stream<A, TClose>) => Stream<B, TClose>;
 
 export interface Node {
   id: string;
   parentId?: string;
-  data: Record<string, unknown>;
+  data: Record<string, Json>;
 }
 
 export type NodeMap = Record<string, Node>;

--- a/lib/update-node-map.ts
+++ b/lib/update-node-map.ts
@@ -1,6 +1,22 @@
-import type { ScopeEvent } from "../../../scope/protocol.ts";
-import type { NodeMap, Transform } from "./types.ts";
-import { reduce } from "../../../lib/reduce.ts";
+import type { ScopeEvent } from "../scope/protocol.ts";
+import { reduce } from "./reduce.ts";
+import type { Stream } from "effection";
+
+/**
+ * A function that transforms one stream into another
+ */
+
+export type Transform<A, B> = <TClose>(
+  input: Stream<A, TClose>,
+) => Stream<B, TClose>;
+
+export interface Node {
+  id: string;
+  parentId?: string;
+  data: Record<string, unknown>;
+}
+
+export type NodeMap = Record<string, Node>;
 
 export function updateNodeMap(
   initial: NodeMap,

--- a/loader.ts
+++ b/loader.ts
@@ -32,6 +32,7 @@ global.around(api.Main, {
         yield* body(args);
       } finally {
         yield* detach();
+        console.log("detached, inspector shut down");
       }
     });
   },

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "expect": "^30.2.0",
     "lightningcss": "^1.31.1",
     "parse-sse": "^0.1.0",
+    "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vite": "^7.3.1",
     "vite-plugin-static-copy": "^3.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,15 +69,18 @@ importers:
       parse-sse:
         specifier: ^0.1.0
         version: 0.1.0
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: ^7.3.1
-        version: 7.3.1(@types/node@22.19.11)(lightningcss@1.31.1)
+        version: 7.3.1(@types/node@22.19.11)(lightningcss@1.31.1)(tsx@4.21.0)
       vite-plugin-static-copy:
         specifier: ^3.2.0
-        version: 3.2.0(vite@7.3.1(@types/node@22.19.11)(lightningcss@1.31.1))
+        version: 3.2.0(vite@7.3.1(@types/node@22.19.11)(lightningcss@1.31.1)(tsx@4.21.0))
 
 packages:
 
@@ -852,6 +855,9 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  get-tsconfig@4.13.6:
+    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -1069,6 +1075,9 @@ packages:
   remeda@2.33.6:
     resolution: {integrity: sha512-tazDGH7s75kUPGBKLvhgBEHMgW+TdDFhjUAMdQj57IoWz6HsGa5D2RX5yDUz6IIqiRRvZiaEHzCzWdTeixc/Kg==}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   rgbcolor@1.0.1:
     resolution: {integrity: sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==}
     engines: {node: '>= 0.8.15'}
@@ -1126,6 +1135,11 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -1902,6 +1916,10 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  get-tsconfig@4.13.6:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -2094,6 +2112,8 @@ snapshots:
 
   remeda@2.33.6: {}
 
+  resolve-pkg-maps@1.0.0: {}
+
   rgbcolor@1.0.1: {}
 
   robust-predicates@3.0.2: {}
@@ -2162,19 +2182,26 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.3
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
 
-  vite-plugin-static-copy@3.2.0(vite@7.3.1(@types/node@22.19.11)(lightningcss@1.31.1)):
+  vite-plugin-static-copy@3.2.0(vite@7.3.1(@types/node@22.19.11)(lightningcss@1.31.1)(tsx@4.21.0)):
     dependencies:
       chokidar: 3.6.0
       p-map: 7.0.4
       picocolors: 1.1.1
       tinyglobby: 0.2.15
-      vite: 7.3.1(@types/node@22.19.11)(lightningcss@1.31.1)
+      vite: 7.3.1(@types/node@22.19.11)(lightningcss@1.31.1)(tsx@4.21.0)
 
-  vite@7.3.1(@types/node@22.19.11)(lightningcss@1.31.1):
+  vite@7.3.1(@types/node@22.19.11)(lightningcss@1.31.1)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -2186,5 +2213,6 @@ snapshots:
       '@types/node': 22.19.11
       fsevents: 2.3.3
       lightningcss: 1.31.1
+      tsx: 4.21.0
 
   zod@4.3.6: {}

--- a/scope/implementation.ts
+++ b/scope/implementation.ts
@@ -12,6 +12,7 @@ import {
 import { pipe } from "remeda";
 import { createSubject } from "@effectionx/stream-helpers";
 import { AttributesContext, getLabels } from "../lib/labels.ts";
+import { updateNodeMap } from "../lib/update-node-map.ts";
 
 const Id = createContext<string>("@effectionx/inspector.id", "global");
 const Children = createContext<Set<Scope>>(
@@ -91,6 +92,12 @@ export const scope = createImplementation(protocol, function* (root) {
     getScopes: op(function* () {
       return readTree(root);
     }),
+    recordNodeMap: () =>
+      pipe(
+        stream,
+        createSubject<ScopeEvent>({ type: "tree", value: readTree(root) }),
+        updateNodeMap({}),
+      ),
   };
 }) as Inspector<typeof protocol.methods>;
 

--- a/scope/protocol.ts
+++ b/scope/protocol.ts
@@ -56,6 +56,7 @@ const $ = scope({
         didHave: "boolean",
       },
     ),
+  NodeMap: "Record<string, ScopeNode>",
   Never: "never",
   None: "never[]",
   Undef: "undefined",
@@ -80,7 +81,7 @@ export const protocol = createProtocol({
   },
   recordNodeMap: {
     args: schema.None,
-    progress: schema.ScopeEvent,
+    progress: schema.NodeMap,
     returns: schema.Undef,
   },
 });

--- a/scope/protocol.ts
+++ b/scope/protocol.ts
@@ -78,4 +78,9 @@ export const protocol = createProtocol({
     progress: schema.Never,
     returns: schema.ScopeTree,
   },
+  recordNodeMap: {
+    args: schema.None,
+    progress: schema.ScopeEvent,
+    returns: schema.Undef,
+  },
 });


### PR DESCRIPTION
# Motivation

Adds new endpoint which will return the `NodeMap` instead of the events.

Requires this published before we can move forward here: https://github.com/thefrontside/effectionx/pull/167

# Approach

Still requires `curl`, but at least it is in steps that can be followed in the readme.
